### PR TITLE
fix: Use Python 3.12 on macOS

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -217,7 +217,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.12'
 
       - name: Checkout DuckDB to version
         run: |


### PR DESCRIPTION
Closes #13.