### PR TITLE
Define DUCKDB_PLATFORM_RTOOLS when compiling for arch rtools

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -313,6 +313,11 @@ jobs:
           cp $OVERLAY_TRIPLET_SRC $OVERLAY_TRIPLET_DST
           echo "set(VCPKG_PLATFORM_TOOLSET_VERSION "14.38")" >> $OVERLAY_TRIPLET_DST
 
+      - name: Populate env for RTOOLS
+        if: matrix.duckdb_arch == 'windows_amd64_rtools'
+        run: |
+          echo "DUCKDB_PLATFORM_RTOOLS=1" >> $GITHUB_ENV
+
       - name: Build & test extension
         env:
           VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/overlay_triplets"


### PR DESCRIPTION
Problem is that otherwise extension can't be linked, see https://github.com/duckdb/sqlite_scanner/actions/runs/9075702375/job/24936875420?pr=93#step:10:2120