### PR TITLE
Separate make clean-python from make clean

### DIFF
--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -96,8 +96,10 @@ wasm_threads:
 format:
 	find src/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
 	cmake-format -i CMakeLists.txt
+
 update:
 	git submodule update --remote --merge
+
 pull:
 	git submodule init
 	git submodule update --recursive --remote
@@ -105,5 +107,7 @@ pull:
 clean:
 	rm -rf build
 	rm -rf testext
-	cd $(DUCKDB_SRCDIR) && make clean
-	cd $(DUCKDB_SRCDIR) && make clean-python
+	make $@ -C $(DUCKDB_SRCDIR)
+
+clean-python:
+	make $@ -C $(DUCKDB_SRCDIR)


### PR DESCRIPTION
So that we don't need a working Python setup for cleanup.

<img width="748" alt="image" src="https://github.com/duckdb/extension-ci-tools/assets/158074/4e2d024b-3618-4683-94d9-a072127d5f88">
