### PR TITLE
Fix CentOS7 going EOL

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -142,6 +142,15 @@ jobs:
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
 
+      - name: Fix CentOS 7 EOL
+        if: ${{ matrix.duckdb_arch == 'linux_amd64_gcc4' }}
+        run: |
+          # Workaround the fact that CentOS 7 is EOL
+          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+          yum-config-manager --disable centos-sclo-rh
+          yum install epel-release -y
+
       - name: Setup ManyLinux2014
         if: ${{ matrix.duckdb_arch == 'linux_amd64_gcc4' }}
         run: |


### PR DESCRIPTION
CentOS 7 is hilariously old, but according to https://mayeut.github.io/manylinux-timeline we are not ready to give up just yet: ~26% of people are not yet on GLIBC 2.28 (which would be the next step up in manylinux-land). So for now we bandaid our manylinux builds. The fix here appears to do the trick, but I will keep an eye on https://github.com/pypa/manylinux/issues/1641 where a different/better solution might get proposed