### PR TITLE
Unroll logic out of github action and into docker + script

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -124,7 +124,6 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.linux_matrix != '{}' && needs.generate_matrix.outputs.linux_matrix != '' }}
     strategy:
@@ -135,138 +134,181 @@ jobs:
       GEN: ninja
       BUILD_SHELL: ${{ inputs.build_duckdb_shell && '1' || '0' }}
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      REPO_REF: ${{ inputs.override_ref }}
+      REPO_NAME: ${{ inputs.override_repository != '' && inputs.override_repository || github.repository }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      ENABLE_RUST: '0'
+      RUST_TARGET: ${{ matrix.duckdb_arch == 'linux_arm64' && 'aarch64-unknown-linux-gnu' || '' }}
+      CC: ${{ matrix.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-gcc' || 'gcc' }}
+      CXX: ${{ matrix.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-g++' || 'g++' }}
+      RUN_TESTS: ${{ matrix.duckdb_arch != 'linux_arm64' && '1' }}
+      AARCH64_CROSS_COMPILE: ${{ matrix.duckdb_arch == 'linux_arm64' && 1 }}
+      CONTAINER: ${{ matrix.container }}
 
     steps:
-      - name: Install required ubuntu packages
-        if: ${{ matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64' }}
+      - name: Setup and build extension
+        shell: bash
         run: |
-          apt-get update -y -qq
-          apt-get install -y -qq software-properties-common
-          add-apt-repository ppa:git-core/ppa
-          apt-get update -y -qq
-          apt-get install -y -qq --fix-missing ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client
-
-      - name: Install Git 2.18.5
-        if: ${{ matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64' }}
-        run: |
-          wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz
-          tar xvf v2.18.5.tar.gz
-          cd git-2.18.5
-          make
-          make prefix=/usr install
-          git --version
-
-      - uses: actions/checkout@v3
-        name: Checkout override repository
-        if: ${{inputs.override_repository != ''}}
-        with:
-          repository: ${{ inputs.override_repository }}
-          ref: ${{ inputs.override_ref }}
-          fetch-depth: 0
-          submodules: 'true'
-
-      - uses: actions/checkout@v3
-        name: Checkout current repository
-        if: ${{inputs.override_repository == ''}}
-        with:
-          fetch-depth: 0
-          submodules: 'true'
-
-      - name: Checkout DuckDB to version
-        run: |
+          export CURR_DIR=/home/runner/work/${GITHUB_REPOSITORY#*/}/${GITHUB_REPOSITORY#*/}
+          cat > script.sh << ENDOFLINE
+          VCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET
+          export VCPKG_BUILD=1
+          CC="${CC}"
+          CXX="${CXX}"
+          GEN="${GEN}"
+          DUCKDB_PLATFORM="${DUCKDB_PLATFORM}"
+          BUILD_SHELL="${BUILD_SHELL}"
+          export VCPKG_TOOLCHAIN_PATH=$CURR_DIR/vcpkg/scripts/buildsystems/vcpkg.cmake
+          set -eo pipefail
+          ###
+          echo "Install required ubuntu packages"
+          cd $CURR_DIR
+          if [ "${DUCKDB_PLATFORM}" != "linux_amd64_gcc4" ]; then
+            apt-get update -y -qq
+            apt-get install -y -qq software-properties-common
+            add-apt-repository ppa:git-core/ppa
+            apt-get update -y -qq
+            apt-get install -y -qq --fix-missing ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client
+          fi
+          ###
+          echo "Install Git 2.18.5"
+          cd $CURR_DIR
+          if [ "${DUCKDB_PLATFORM}" != "linux_amd64_gcc4" ]; then
+            wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz
+            tar xvf v2.18.5.tar.gz
+            cd git-2.18.5
+            make
+            make prefix=/usr install
+            git --version
+          fi
+          ###
+          echo "Checkout"
+          cd $CURR_DIR
+          git init
+          git config --global --add safe.directory $CURR_DIR
+          git remote add origin https://github.com/$REPO_NAME
+          git fetch
+          git checkout main
+          git checkout $REPO_REF
+          git submodule init
+          git submodule update
+          ###
+          echo "Checkout DuckDB to version"
+          cd $CURR_DIR
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
-
-      - name: Fix CentOS 7 EOL
-        if: ${{ matrix.duckdb_arch == 'linux_amd64_gcc4' }}
-        run: |
-          # Workaround the fact that CentOS 7 is EOL
-          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-          yum-config-manager --disable centos-sclo-rh
-          yum install epel-release -y
-
-      - name: Setup ManyLinux2014
-        if: ${{ matrix.duckdb_arch == 'linux_amd64_gcc4' }}
-        run: |
-          ./duckdb/scripts/setup_manylinux2014.sh general aws-cli ccache ssh python_alias openssl
-
-      - name: Setup Ubuntu
-        if: ${{ matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64' }}
-        uses: ./duckdb/.github/actions/ubuntu_18_setup
-        with:
-          aarch64_cross_compile: ${{ matrix.duckdb_arch == 'linux_arm64' && 1 }}
-
-      - uses: actions/checkout@v3
-        name: Checkout override repository
-        if: ${{inputs.override_repository != ''}}
-        with:
-          repository: ${{ inputs.override_repository }}
-          ref: ${{ inputs.override_ref }}
-          fetch-depth: 0
-          submodules: 'true'
-
-      - uses: actions/checkout@v3
-        name: Checkout current repository
-        if: ${{inputs.override_repository == ''}}
-        with:
-          fetch-depth: 0
-          submodules: 'true'
-
-      - name: Checkout DuckDB to version
-        run: |
+          ###
+          echo "Fix CentOS 7 EOL"
+          cd $CURR_DIR
+          if [[ "${DUCKDB_PLATFORM}" = "linux_amd64_gcc4" ]]; then
+            # Workaround the fact that CentOS 7 is EOL
+            sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+            sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+            yum-config-manager --disable centos-sclo-rh
+            yum install epel-release -y curl
+          fi
+          ###
+          echo "Setup ManyLinux2014"
+          cd $CURR_DIR
+          if [ "${DUCKDB_PLATFORM}" = "linux_amd64_gcc4" ]; then
+            ./duckdb/scripts/setup_manylinux2014.sh general aws-cli ccache ssh python_alias openssl vcpkg
+          else
+            apt-get update -y -qq
+            apt-get install -y -qq software-properties-common
+            add-apt-repository ppa:git-core/ppa
+            apt-get update -y -qq
+            apt-get install -y -qq --fix-missing ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client pkg-config git
+            wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.sh
+            chmod +x cmake-3.21.3-linux-x86_64.sh
+            ./cmake-3.21.3-linux-x86_64.sh --skip-license --prefix=/usr/local
+            cmake --version
+            # echo "Install Python 3.8"
+            # wget https://www.python.org/ftp/python/3.8.17/Python-3.8.17.tgz
+            # tar xvf Python-3.8.17.tgz
+            # cd Python-3.8.17
+            # mkdir -p pythonbin
+            # ./configure --with-ensurepip=install
+            # make -j
+            # make install
+            # python3.8 --version
+            # python3.8 -m pip install pip
+            # python3.8 -m pip install requests awscli
+            echo "Install"
+            if [ -n "${AARCH64_CROSS_COMPILE}" ]; then
+              apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+            fi
+            git checkout ${{ inputs.git_ref }}
+            #python3 --version
+            #python3 -m pip install pip
+            #python3 -m pip install requests awscli
+            echo "Version Check"
+            ldd --version ldd
+            #python3 --version
+            git --version
+            git log -1 --format=%h
+          fi
+          ###
+          echo "Checkout, again"
+          cd $CURR_DIR
+          git checkout $REPO_REF
+          ###
+          echo "Checkout DuckDB to version"
+          cd $CURR_DIR
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
-
-      - name: Setup Rust
-        if: ${{ inputs.enable_rust && matrix.duckdb_arch == 'linux_amd64'}}
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Setup Rust for cross compilation
-        if: ${{ inputs.enable_rust && matrix.duckdb_arch == 'linux_arm64'}}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-unknown-linux-gnu
-
-      - name: Setup Rust for manylinux (dtolnay/rust-toolchain doesn't work due to curl being old here)
-        if: ${{ inputs.enable_rust && matrix.duckdb_arch == 'linux_amd64_gcc4' }}
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y 
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11 # Note: pinned due to GLIBC incompatibility in later releases
-        continue-on-error: true
-        with:
-          key: ${{ github.job }}-${{ matrix.duckdb_arch }}
-
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11.1
-        with:
-          vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
-
-      - name: Configure OpenSSL for Rust
-        if: ${{ inputs.enable_rust }}
-        run: |
-          echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
-          echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
-          echo "OPENSSL_USE_STATIC_LIBS=true" >> $GITHUB_ENV
-
-      - name: Build extension
-        env:
-          GEN: ninja
-          CC: ${{ matrix.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-gcc' || '' }}
-          CXX: ${{ matrix.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-g++' || '' }}
-          DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-        run: |
+          ###
+          echo "Setup Rust for manylinux (dtolnay/rust-toolchain doesn't work due to curl being old here)"
+          cd $CURR_DIR
+          if [ -n "${ENABLE_RUST}" ]; then
+            echo "ASDASDASD"
+            curl --proto "https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "ASDASDASD"
+            PATH="$HOME/.cargo/bin:$PATH"
+            echo "ASDASDASD"
+            . "$HOME/.cargo/env"
+            echo "ASDASDASD"
+            if [ -n "${RUST_TARGET}" ]; then
+              $HOME/.cargo/bin/rustup target add $RUST_TARGET
+            fi
+          fi
+          # - name: Setup Ccache
+          #   uses: hendrikmuhs/ccache-action@v1.2.11 # Note: pinned due to GLIBC incompatibility in later releases
+          #   continue-on-error: true
+          #   with:
+          #      key: ${{ github.job }}-${{ matrix.duckdb_arch }}
+          ###
+          echo "Setup vcpkg"
+          cd $CURR_DIR
+          git clone https://github.com/microsoft/vcpkg.git
+          cd vcpkg
+          git fetch
+          git checkout a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6
+          ./bootstrap-vcpkg.sh
+          ###
+          #echo "Configure OpenSSL for Rust"
+          #cd $CURR_DIR
+          #if [ -n "${ENABLE_RUST}" ]; then
+          OPENSSL_ROOT_DIR=$CURR_DIR/build/release/vcpkg_installed/$VCPKG_TARGET_TRIPLET
+          OPENSSL_DIR=$CURR_DIR/build/release/vcpkg_installed/$VCPKG_TARGET_TRIPLET
+          OPENSSL_INCLUDE_DIR=$CURR_DIR/build/release/vcpkg_installed/$VCPKG_TARGET_TRIPLET/include
+          OPENSSL_USE_STATIC_LIBS=true
+          #fi
+          ###
+          echo "Build extension"
+          cd $CURR_DIR
+          # export VCPKG_TOOLCHAIN_PATH=/home/runner/work/quack/quack/vcpkgs/script/buildsystems/vcpkg.cmake
           make release
+          ###
+          echo "Test extension"
+          cd $CURR_DIR
+          if [ -n "${RUN_TESTS}" ]; then
+            make test
+          fi
+          ENDOFLINE
+          chmod +x script.sh
+          cat script.sh | docker run -i --rm -v /home/runner/work:/home/runner/work --workdir $CURR_DIR $CONTAINER
 
-      - name: Test extension
-        if: ${{ matrix.duckdb_arch != 'linux_arm64'}}
-        run: |
-          make test
-
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -131,7 +131,6 @@ jobs:
     env:
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
-      GEN: ninja
       BUILD_SHELL: ${{ inputs.build_duckdb_shell && '1' || '0' }}
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
       REPO_REF: ${{ inputs.override_ref }}
@@ -151,13 +150,10 @@ jobs:
         run: |
           export CURR_DIR=/home/runner/work/${GITHUB_REPOSITORY#*/}/${GITHUB_REPOSITORY#*/}
           cat > script.sh << ENDOFLINE
-          VCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET
+          VCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}
           export VCPKG_BUILD=1
-          CC="${CC}"
-          CXX="${CXX}"
-          GEN="${GEN}"
-          DUCKDB_PLATFORM="${DUCKDB_PLATFORM}"
-          BUILD_SHELL="${BUILD_SHELL}"
+          export DUCKDB_PLATFORM="${DUCKDB_PLATFORM}"
+          export BUILD_SHELL="${BUILD_SHELL}"
           export VCPKG_TOOLCHAIN_PATH=$CURR_DIR/vcpkg/scripts/buildsystems/vcpkg.cmake
           set -eo pipefail
           ###
@@ -257,16 +253,22 @@ jobs:
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
           ###
+          echo "Setup vcpkg"
+          cd $CURR_DIR
+          git clone https://github.com/microsoft/vcpkg.git
+          cd vcpkg
+          git fetch
+          git checkout a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6
+          #export CC="${CC}"
+          #export CXX="${CXX}"
+          ./bootstrap-vcpkg.sh
+          ###
           echo "Setup Rust for manylinux (dtolnay/rust-toolchain doesn't work due to curl being old here)"
           cd $CURR_DIR
           if [ -n "${ENABLE_RUST}" ]; then
-            echo "ASDASDASD"
             curl --proto "https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            echo "ASDASDASD"
-            PATH="$HOME/.cargo/bin:$PATH"
-            echo "ASDASDASD"
-            . "$HOME/.cargo/env"
-            echo "ASDASDASD"
+            #PATH="$HOME/.cargo/bin:$PATH"
+            #. "$HOME/.cargo/env"
             if [ -n "${RUST_TARGET}" ]; then
               $HOME/.cargo/bin/rustup target add $RUST_TARGET
             fi
@@ -276,14 +278,6 @@ jobs:
           #   continue-on-error: true
           #   with:
           #      key: ${{ github.job }}-${{ matrix.duckdb_arch }}
-          ###
-          echo "Setup vcpkg"
-          cd $CURR_DIR
-          git clone https://github.com/microsoft/vcpkg.git
-          cd vcpkg
-          git fetch
-          git checkout a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6
-          ./bootstrap-vcpkg.sh
           ###
           #echo "Configure OpenSSL for Rust"
           #cd $CURR_DIR
@@ -297,7 +291,9 @@ jobs:
           echo "Build extension"
           cd $CURR_DIR
           # export VCPKG_TOOLCHAIN_PATH=/home/runner/work/quack/quack/vcpkgs/script/buildsystems/vcpkg.cmake
-          make release
+          #export CC="${CC}"
+          #export CXX="${CXX}"
+          GEN=ninja make release
           ###
           echo "Test extension"
           cd $CURR_DIR

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -137,7 +137,6 @@ jobs:
       REPO_NAME: ${{ inputs.override_repository != '' && inputs.override_repository || github.repository }}
       GITHUB_REPOSITORY: ${{ github.repository }}
       ENABLE_RUST: '0'
-      RUST_TARGET: ${{ matrix.duckdb_arch == 'linux_arm64' && 'aarch64-unknown-linux-gnu' || '' }}
       CC: ${{ matrix.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-gcc' || 'gcc' }}
       CXX: ${{ matrix.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-g++' || 'g++' }}
       RUN_TESTS: ${{ matrix.duckdb_arch != 'linux_arm64' && '1' }}
@@ -269,9 +268,6 @@ jobs:
             curl --proto "https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             #PATH="$HOME/.cargo/bin:$PATH"
             #. "$HOME/.cargo/env"
-            if [ -n "${RUST_TARGET}" ]; then
-              $HOME/.cargo/bin/rustup target add $RUST_TARGET
-            fi
           fi
           # - name: Setup Ccache
           #   uses: hendrikmuhs/ccache-action@v1.2.11 # Note: pinned due to GLIBC incompatibility in later releases


### PR DESCRIPTION
Tests for this will be at:

* https://github.com/carlopi/duckdb-prql/actions/runs/9828432717
* https://github.com/carlopi/quack/actions/runs/9828404400/job/27132261289

Tradeoffs between approaches are not trivial, in particular we are temporarily doing without ccache, but I think this is the proper way out of this.