### PR TITLE
add option to enable extra toolchains, deprecated enable_rust

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -28,10 +28,10 @@ jobs:
     uses: ./.github/workflows/_extension_distribution.yml
     with:
       extension_name: delta
-      enable_rust: true
       override_repository: duckdb/duckdb_delta
       override_ref: main
       override_ci_tools_repository: ${{ github.repository }}
       override_ci_tools_ref: ${{ github.sha }}
       duckdb_version: v1.0.0
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
+      extra_toolchains: 'rust'

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -186,7 +186,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Rust for cross compilation
-        if: ${{ inputs.enable_rust && matrix.duckdb_arch == 'linux_arm64'}}
+        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && matrix.duckdb_arch == 'linux_arm64'}}
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-unknown-linux-gnu

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -45,10 +45,6 @@ on:
         required: false
         type: boolean
         default: true
-      enable_rust:
-        required: false
-        type: boolean
-        default: false
       # Supply an override repository to build, instead of using the current one
       override_repository:
         required: false
@@ -69,7 +65,17 @@ on:
         required: false
         type: string
         default: ""
-
+      # Pass extra toolchains
+      #   available: (rust)
+      extra_toolchains:
+        required: false
+        type: string
+        default: ""
+      # DEPRECATED: use extra_toolchains instead
+      enable_rust:
+        required: false
+        type: boolean
+        default: false
 jobs:
   generate_matrix:
     name: Generate matrix
@@ -176,7 +182,7 @@ jobs:
           git --version
 
       - name: Setup Rust
-        if: ${{ inputs.enable_rust && matrix.duckdb_arch == 'linux_amd64'}}
+        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && matrix.duckdb_arch == 'linux_amd64'}}
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Rust for cross compilation
@@ -186,7 +192,7 @@ jobs:
           targets: aarch64-unknown-linux-gnu
 
       - name: Setup Rust for manylinux (dtolnay/rust-toolchain doesn't work due to curl being old here)
-        if: ${{ inputs.enable_rust && matrix.duckdb_arch == 'linux_amd64_gcc4' }}
+        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && matrix.duckdb_arch == 'linux_amd64_gcc4' }}
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y 
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
@@ -253,7 +259,7 @@ jobs:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
 
       - name: Configure OpenSSL for Rust
-        if: ${{ inputs.enable_rust }}
+        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
         run: |
           echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
           echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
@@ -348,7 +354,7 @@ jobs:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
 
       - name: Install Rust cross compile dependency
-        if: ${{ inputs.enable_rust && matrix.osx_build_arch == 'x86_64'}}
+        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && matrix.osx_build_arch == 'x86_64'}}
         run: |
           rustup target add x86_64-apple-darwin
 
@@ -415,7 +421,7 @@ jobs:
           python-version: '3.11'
 
       - name: Setup Rust
-        if: inputs.enable_rust
+        if: (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;'))
         uses: dtolnay/rust-toolchain@stable
 
       - uses: r-lib/actions/setup-r@v2
@@ -512,7 +518,7 @@ jobs:
           version: 'latest'
 
       - name: Setup Rust for cross compilation
-        if: ${{ inputs.enable_rust}}
+        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;'))}}
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-emscripten


### PR DESCRIPTION
This will allow us to add more toolchains dynamically to enable more flexibility in building extensions that require extra toolchain setup.

We reduce the risk of an extension requiring some toolchain to be present to break other extension's CI