### PR TITLE
Pass the compilers using CMAKE_XXX_COMPILER instead of XXX env variable

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -286,8 +286,7 @@ jobs:
       - name: Build extension
         env:
           GEN: ninja
-          CC: ${{ matrix.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-gcc' || '' }}
-          CXX: ${{ matrix.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-g++' || '' }}
+          TOOLCHAIN_FLAGS: ${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}
           DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
         run: |
           make release


### PR DESCRIPTION
Semi-unsolicited PR, below small explanation on why this is needed. Also tagging @hannes as this is one of the changes we discussed on friday WRT the getting faiss extension in the community repo.

The previous method of setting the CC and friends environment variables causes some issues with some vcpkg ports. Sometimes a port must be compiled for the host, but when the CC env variable is set, this overwrites all settings. This leads to a situation where code that must be compiled for the host architecture (eg amd64) will be compiled with an arm64 cross-compiler.