### PR TITLE
Add rust logging

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -31,9 +31,9 @@ jobs:
     with:
       extension_name: delta
       override_repository: duckdb/duckdb_delta
-      override_ref: 3933ebd800ad06a64656c9aef6ca7d62897fa4db
+      override_ref: 94f887bd539ec0d5ed0d31bd01ff3845cf378a9d
       override_ci_tools_repository: ${{ github.repository }}
       override_ci_tools_ref: ${{ github.sha }}
-      duckdb_version: fa2daf7a09e477e30e53b4cc8f4269c39eaf62ef
+      duckdb_version: 45787e5f9f8bdb9dce97890c1ac7a7eb2dc3a49f
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
       extra_toolchains: 'rust'

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -31,7 +31,7 @@ jobs:
     with:
       extension_name: delta
       override_repository: duckdb/duckdb_delta
-      override_ref: main
+      override_ref: 3933ebd800ad06a64656c9aef6ca7d62897fa4db
       override_ci_tools_repository: ${{ github.repository }}
       override_ci_tools_ref: ${{ github.sha }}
       duckdb_version: v1.0.0

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -34,6 +34,6 @@ jobs:
       override_ref: 3933ebd800ad06a64656c9aef6ca7d62897fa4db
       override_ci_tools_repository: ${{ github.repository }}
       override_ci_tools_ref: ${{ github.sha }}
-      duckdb_version: v1.0.0
+      duckdb_version: fa2daf7a09e477e30e53b4cc8f4269c39eaf62ef
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
       extra_toolchains: 'rust'

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -332,6 +332,15 @@ jobs:
           path: |
             build/release/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
 
+      - name: Print Rust logs
+        if: ${{ always() && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
+        run: |
+          for filename in build/release/rust/src/*/*build-*.log; do 
+            echo Printing logs for file $filename
+            cat $filename;
+            echo Done printing logs for $filename
+          done
+
   macos:
     name: MacOS
     runs-on: macos-latest
@@ -455,6 +464,15 @@ jobs:
           path: |
             build/release/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
 
+      - name: Print Rust logs
+        if: ${{ always() && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
+        run: |
+          for filename in build/release/rust/src/*/*build-*.log; do 
+            echo Printing logs for file $filename
+            cat $filename;
+            echo Done printing logs for $filename
+          done
+
   windows:
     name: Windows
     runs-on: windows-latest
@@ -559,6 +577,15 @@ jobs:
           path: |
             build/release/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
 
+      - name: Print Rust logs
+        if: ${{ always() && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
+        run: |
+          for filename in build/release/rust/src/*/*build-*.log; do 
+            echo Printing logs for file $filename
+            cat $filename;
+            echo Done printing logs for $filename
+          done
+
   wasm:
     name: DuckDB-Wasm
     runs-on: ubuntu-latest
@@ -640,3 +667,12 @@ jobs:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: |
             build/${{ matrix.duckdb_arch }}/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension.wasm
+
+      - name: Print Rust logs
+        if: ${{ always() && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
+        run: |
+          for filename in build/release/rust/src/*/*build-*.log; do 
+            echo Printing logs for file $filename
+            cat $filename;
+            echo Done printing logs for $filename
+          done

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -670,6 +670,7 @@ jobs:
 
       - name: Print Rust logs
         if: ${{ always() && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
+        shell: bash
         run: |
           for filename in build/release/rust/src/*/*build-*.log; do 
             echo Printing logs for file $filename


### PR DESCRIPTION
Prints the build logs for any rust code that is built through cmake. Useful for issues like https://github.com/duckdb/duckdb/issues/12983