### PR TITLE
Update upload-artifact from v2 to v3

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -326,7 +326,7 @@ jobs:
         run: |
           make test
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: |


### PR DESCRIPTION
Using the deprecated version is breaking the pipeline

![image](https://github.com/user-attachments/assets/1b785249-2a61-4055-80dd-0ddbdc4de070)

It was working yesterday but I guess Github finally disabled the old versions.

Upgrading to v3 fixed the pipeline. 

![image](https://github.com/user-attachments/assets/67088b32-f186-49dd-b65f-b58af2e2ca76)
