### PR TITLE
Add setup-go to _extension_distribution for compiling go extensions

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -212,6 +212,11 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y 
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: 'Setup go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          
       - name: Install CMake 3.21
         if: ${{ matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64' }}
         shell: bash
@@ -403,6 +408,11 @@ jobs:
         run: |
           rustup target add x86_64-apple-darwin
 
+      - name: 'Setup go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
       - name: Install parser tools
         if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';parser_tools;')}}
         run: |
@@ -500,6 +510,11 @@ jobs:
       - name: Setup Rust
         if: (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;'))
         uses: dtolnay/rust-toolchain@stable
+
+      - name: 'Setup go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
 
       - name: Install parser tools
         if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';parser_tools;')}}
@@ -611,6 +626,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-emscripten
+
+      - name: 'Setup go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11.1


### PR DESCRIPTION
I'm building an extension in go and the CI complains currently about building go. This PR add go dependency. 

I'm not sure if the PR should go to 1.1 or main. 