### PR TITLE
Add opt-in go toolchain to CI extension template

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -22,7 +22,7 @@ jobs:
       duckdb_version: v1.1.0
       override_ci_tools_repository: ${{ github.repository }}
       override_ci_tools_ref: ${{ github.sha }}
-      extra_toolchains: 'parser_tools;fortran;omp'
+      extra_toolchains: 'parser_tools;fortran;omp;go'
       custom_toolchain_script: true
 
   delta-extension-main:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -457,7 +457,7 @@ jobs:
 
   windows:
     name: Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.windows_matrix != '{}' && needs.generate_matrix.outputs.windows_matrix != '' }}
     strategy:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -82,6 +82,10 @@ on:
         type: boolean
         default: false
       # DEPRECATED: use extra_toolchains instead
+      enable_go:
+        required: false
+        type: boolean
+        default: false
       enable_rust:
         required: false
         type: boolean
@@ -213,10 +217,11 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: 'Setup go'
-        uses: actions/setup-go@v5
+        if: ${{ (inputs.enable_go || contains(format(';{0};', inputs.extra_toolchains), ';go;'))}}
+        uses: actions/setup-go@v4
         with:
           go-version: '1.23'
-          
+
       - name: Install CMake 3.21
         if: ${{ matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64' }}
         shell: bash
@@ -409,7 +414,8 @@ jobs:
           rustup target add x86_64-apple-darwin
 
       - name: 'Setup go'
-        uses: actions/setup-go@v5
+        if: ${{ (inputs.enable_go || contains(format(';{0};', inputs.extra_toolchains), ';go;'))}}
+        uses: actions/setup-go@v4
         with:
           go-version: '1.23'
 
@@ -512,7 +518,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: 'Setup go'
-        uses: actions/setup-go@v5
+        if: ${{ (inputs.enable_go || contains(format(';{0};', inputs.extra_toolchains), ';go;'))}}
+        uses: actions/setup-go@v4
         with:
           go-version: '1.23'
 
@@ -628,7 +635,8 @@ jobs:
           targets: wasm32-unknown-emscripten
 
       - name: 'Setup go'
-        uses: actions/setup-go@v5
+        if: ${{ (inputs.enable_go || contains(format(';{0};', inputs.extra_toolchains), ';go;'))}}
+        uses: actions/setup-go@v4
         with:
           go-version: '1.23'
 

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -212,6 +212,11 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y 
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: 'Setup go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          
       - name: Install CMake 3.21
         if: ${{ matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64' }}
         shell: bash
@@ -403,6 +408,11 @@ jobs:
         run: |
           rustup target add x86_64-apple-darwin
 
+      - name: 'Setup go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
       - name: Install parser tools
         if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';parser_tools;')}}
         run: |
@@ -500,6 +510,11 @@ jobs:
       - name: Setup Rust
         if: (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;'))
         uses: dtolnay/rust-toolchain@stable
+
+      - name: 'Setup go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
 
       - name: Install parser tools
         if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';parser_tools;')}}
@@ -611,6 +626,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-emscripten
+
+      - name: 'Setup go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11.1


### PR DESCRIPTION
Similar to rust toolchain, it uses an opt-in flag `enable_go` to install the toolchain.

```
  duckdb-next-build:
    ...
    with:
      ...
      enable_go: true
```

This is useful for building duckdb extensions in Go. 
See example repository https://github.com/ajzo90/duckdb-go-extension-example
