### PR TITLE
Switch to manual docker

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -24,7 +24,7 @@ jobs:
       override_ci_tools_ref: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp'
       custom_toolchain_script: true
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;linux_amd64;linux_arm64'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;linux_amd64;linux_arm64;osx_amd64;osx_arm64'
 
 #  delta-extension-main:
 #    name: Rust builds (using Delta extension)

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -23,6 +23,7 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       override_ci_tools_ref: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp;go'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;osx_arm64;osx_amd64'
       custom_toolchain_script: true
 
   delta-extension-main:
@@ -35,5 +36,5 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       override_ci_tools_ref: ${{ github.sha }}
       duckdb_version: v1.1.0
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;osx_arm64;osx_amd64'
       extra_toolchains: 'rust'

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -26,15 +26,15 @@ jobs:
       custom_toolchain_script: true
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;osx_amd64;osx_arm64'
 
-#  delta-extension-main:
-#    name: Rust builds (using Delta extension)
-#    uses: ./.github/workflows/_extension_distribution.yml
-#    with:
-#      extension_name: delta
-#      override_repository: duckdb/duckdb_delta
-#      override_ref: main
-#      override_ci_tools_repository: ${{ github.repository }}
-#      override_ci_tools_ref: ${{ github.sha }}
-#      duckdb_version: v1.1.0
-#      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;linux_amd64;linux_arm64'
-#      extra_toolchains: 'rust'
+  delta-extension-main:
+    name: Rust builds (using Delta extension)
+    uses: ./.github/workflows/_extension_distribution.yml
+    with:
+      extension_name: delta
+      override_repository: duckdb/duckdb_delta
+      override_ref: main
+      override_ci_tools_repository: ${{ github.repository }}
+      override_ci_tools_ref: ${{ github.sha }}
+      duckdb_version: v1.1.0
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;osx_amd64;osx_arm64'
+      extra_toolchains: 'rust'

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -24,7 +24,7 @@ jobs:
       override_ci_tools_ref: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp'
       custom_toolchain_script: true
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;linux_amd64;linux_arm64;osx_amd64;osx_arm64'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;osx_amd64;osx_arm64'
 
 #  delta-extension-main:
 #    name: Rust builds (using Delta extension)

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -24,7 +24,6 @@ jobs:
       override_ci_tools_ref: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp'
       custom_toolchain_script: true
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;osx_amd64;osx_arm64'
 
   delta-extension-main:
     name: Rust builds (using Delta extension)
@@ -36,5 +35,5 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       override_ci_tools_ref: ${{ github.sha }}
       duckdb_version: v1.1.0
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;osx_amd64;osx_arm64'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;'
       extra_toolchains: 'rust'

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -24,16 +24,17 @@ jobs:
       override_ci_tools_ref: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp'
       custom_toolchain_script: true
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;linux_amd64;linux_arm64'
 
-  delta-extension-main:
-    name: Rust builds (using Delta extension)
-    uses: ./.github/workflows/_extension_distribution.yml
-    with:
-      extension_name: delta
-      override_repository: duckdb/duckdb_delta
-      override_ref: main
-      override_ci_tools_repository: ${{ github.repository }}
-      override_ci_tools_ref: ${{ github.sha }}
-      duckdb_version: v1.1.0
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
-      extra_toolchains: 'rust'
+#  delta-extension-main:
+#    name: Rust builds (using Delta extension)
+#    uses: ./.github/workflows/_extension_distribution.yml
+#    with:
+#      extension_name: delta
+#      override_repository: duckdb/duckdb_delta
+#      override_ref: main
+#      override_ci_tools_repository: ${{ github.repository }}
+#      override_ci_tools_ref: ${{ github.sha }}
+#      duckdb_version: v1.1.0
+#      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;linux_amd64;linux_arm64'
+#      extra_toolchains: 'rust'

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -23,7 +23,6 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       override_ci_tools_ref: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp;go'
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;osx_arm64;osx_amd64'
       custom_toolchain_script: true
 
   delta-extension-main:
@@ -36,5 +35,5 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       override_ci_tools_ref: ${{ github.sha }}
       duckdb_version: v1.1.0
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;osx_arm64;osx_amd64'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64'
       extra_toolchains: 'rust'

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -56,7 +56,7 @@ jobs:
     outputs:
       deploy_matrix: ${{ steps.parse-matrices.outputs.deploy_matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'true'
@@ -82,7 +82,7 @@ jobs:
       matrix: ${{fromJson(needs.generate_matrix.outputs.deploy_matrix)}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'true'

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -82,10 +82,6 @@ on:
         type: boolean
         default: false
       # DEPRECATED: use extra_toolchains instead
-      enable_go:
-        required: false
-        type: boolean
-        default: false
       enable_rust:
         required: false
         type: boolean
@@ -201,7 +197,11 @@ jobs:
       - name: Build Docker image
         shell: bash
         run: |
-          docker build -t duckdb/${{ matrix.duckdb_arch }} ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
+          docker build \
+            --build-arg 'extra_toolchains=${{ inputs.extra_toolchains }}'
+            --build-arg 'enable_rust=${{ inputs.enable_rust && '1' || '0' }}'
+            -t duckdb/${{ matrix.duckdb_arch }} \
+            ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
 
       - name: Build extension
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -216,6 +216,10 @@ jobs:
           echo "DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}" >> docker_env.txt
           echo "TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}" >> docker_env.txt
 
+      - name: Create ccache dirs
+        run: |
+          touch ./ccache-dir
+
       - name: Configure cache for ccache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -151,7 +151,6 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.linux_matrix != '{}' && needs.generate_matrix.outputs.linux_matrix != '' }}
     strategy:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -224,8 +224,7 @@ jobs:
 
       - name: Create ccache dirs
         run: |
-          touch ./ccache_dir
-          chmod 755 ./ccache_dir
+          mkdir ccache_dir
 
       - name: ccache cache files
         uses: actions/cache@v4

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -199,24 +199,16 @@ jobs:
         run: |
           docker build -t duckdb/${{ matrix.duckdb_arch }} ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
 
-      - name: Build extension
+      - name: Build & test extension
         run: |
           docker run \
+            -e VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \
+            -e BUILD_SHELL=${{ inputs.build_duckdb_shell && '1' || '0' }} \
             -e OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
             -e OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
             -e OPENSSL_USE_STATIC_LIBS=true \
             -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
             -e TOOLCHAIN_FLAGS='${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}' \
-            -v .:/duckdb_build_dir \
-            duckdb/${{ matrix.duckdb_arch }} \
-            make release
-
-      - name: Test extension
-        if: ${{ matrix.duckdb_arch != 'linux_arm64'}}
-        run: |
-          docker run \
-            -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
-            -e TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }} \
             -v .:/duckdb_build_dir \
             duckdb/${{ matrix.duckdb_arch }} \
             make test

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -228,7 +228,7 @@ jobs:
           touch ./ccache-dir
 
       - name: ccache cache files
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v4
         with:
           path: ./ccache-dir
           key: ${{ matrix.duckdb_arch }}-ccache-${{ steps.ccache_timestamp.outputs.timestamp }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -205,16 +205,19 @@ jobs:
             -t duckdb/${{ matrix.duckdb_arch }} \
             ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
 
+      - name: Set up environment variables to be passed to docker
+        run: |
+          echo "DOCKER_ENV_VARS='-e VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \
+          -e BUILD_SHELL=${{ inputs.build_duckdb_shell && '1' || '0' }} \
+          -e OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
+          -e OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
+          -e OPENSSL_USE_STATIC_LIBS=true \
+          -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
+          -e TOOLCHAIN_FLAGS='${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}''" >> $GITHUB_ENV
+
       - name: Build extension
         run: |
-          docker run \
-            -e VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \
-            -e BUILD_SHELL=${{ inputs.build_duckdb_shell && '1' || '0' }} \
-            -e OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
-            -e OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
-            -e OPENSSL_USE_STATIC_LIBS=true \
-            -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
-            -e TOOLCHAIN_FLAGS='${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}' \
+          docker run ${{ env.DOCKER_ENV_VARS }} \ 
             -v .:/duckdb_build_dir \
             duckdb/${{ matrix.duckdb_arch }} \
             make release
@@ -222,14 +225,7 @@ jobs:
       - name: Test extension
         if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
         run: |
-          docker run \
-            -e VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \
-            -e BUILD_SHELL=${{ inputs.build_duckdb_shell && '1' || '0' }} \
-            -e OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
-            -e OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
-            -e OPENSSL_USE_STATIC_LIBS=true \
-            -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
-            -e TOOLCHAIN_FLAGS='${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}' \
+          docker run ${{ env.DOCKER_ENV_VARS }} \
             -v .:/duckdb_build_dir \
             duckdb/${{ matrix.duckdb_arch }} \
             make test

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -207,13 +207,13 @@ jobs:
 
       - name: Set up environment variables to be passed to docker
         run: |
-          echo "DOCKER_ENV_VARS='-e VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \
+          echo "DOCKER_ENV_VARS=-e VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \
           -e BUILD_SHELL=${{ inputs.build_duckdb_shell && '1' || '0' }} \
           -e OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
           -e OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
           -e OPENSSL_USE_STATIC_LIBS=true \
           -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
-          -e TOOLCHAIN_FLAGS='${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}''" >> $GITHUB_ENV
+          -e TOOLCHAIN_FLAGS='${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}'" >> $GITHUB_ENV
 
       - name: Build extension
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -205,7 +205,7 @@ jobs:
             -t duckdb/${{ matrix.duckdb_arch }} \
             ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
 
-      - name: Set up environment variables to be passed to docker
+      - name: Create env file for docker
         run: |
           touch docker_env.txt
           echo "VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }}" >> docker_env.txt 
@@ -216,10 +216,15 @@ jobs:
           echo "DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}" >> docker_env.txt
           echo "TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}" >> docker_env.txt
 
+      - name: Create ccache dir (TODO populate using gh cache)
+        run: |
+          mkdir ccache_dir
+
       - name: Build extension
         run: |
-          docker --env-file docker_env.txt \ 
+          docker run --env-file docker_env.txt \ 
             -v .:/duckdb_build_dir \
+            -v ./ccache_dir:/ccache_dir \
             duckdb/${{ matrix.duckdb_arch }} \
             make release
 
@@ -230,6 +235,11 @@ jobs:
             -v .:/duckdb_build_dir \
             duckdb/${{ matrix.duckdb_arch }} \
             make test
+
+      - name: debug step
+        run: |
+          ls ccache_dir
+          tree ccache_dir
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -210,7 +210,7 @@ jobs:
           docker run \
             -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
             -e TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }} \
-            -v ~/Development/extension-template:/duckdb_extension \
+            -v .:/duckdb_build_dir \
             duckdb/${{ matrix.duckdb_arch }} \
             make release
 
@@ -220,7 +220,7 @@ jobs:
           docker run \
             -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
             -e TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }} \
-            -v ~/Development/extension-template:/duckdb_extension \
+            -v .:/duckdb_build_dir \
             duckdb/${{ matrix.duckdb_arch }} \
             make test
 

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -216,9 +216,11 @@ jobs:
           echo "DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}" >> docker_env.txt
           echo "TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}" >> docker_env.txt
 
-      - name: Create ccache dir (TODO populate using gh cache)
-        run: |
-          mkdir ccache_dir
+      - name: Configure cache for ccache
+        uses: actions/cache@v4
+        with:
+          path: ./ccache-dir
+          key: ${{ github.job }}-${{ matrix.duckdb_arch }}
 
       - name: Build extension
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -198,7 +198,9 @@ jobs:
         shell: bash
         run: |
           docker build \
-            --build-arg 'extra_toolchains=${{ inputs.extra_toolchains }}' \
+            --build-arg 'vcpkg_url=${{ inputs.vcpkg_url }}' \
+            --build-arg 'vcpkg_commit=${{ inputs.vcpkg_commit }}' \
+            --build-arg 'extra_toolchains=${{ format(';{0};', inputs.extra_toolchains) }}' \
             --build-arg 'enable_rust=${{ inputs.enable_rust && '1' || '0' }}' \
             -t duckdb/${{ matrix.duckdb_arch }} \
             ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -471,6 +471,7 @@ jobs:
 
       - name: Print Rust logs
         if: ${{ always() && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
+        shell: bash
         run: |
           for filename in build/release/rust/src/*/*build-*.log; do 
             echo Printing logs for file $filename

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -215,24 +215,24 @@ jobs:
           echo "DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}" >> docker_env.txt
           echo "TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}" >> docker_env.txt
 
-      - name: Prepare ccache timestamp
+      - name: Generate timestamp for Ccache entry
         shell: cmake -P {0}
         id: ccache_timestamp
         run: |
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
           message("::set-output name=timestamp::${current_date}")
 
-      - name: Create ccache dirs
+      - name: Create Ccache directory
         run: |
           mkdir ccache_dir
 
-      - name: ccache cache files
+      - name: Load Ccache
         uses: actions/cache@v4
         with:
           path: ./ccache_dir
-          key: ${{ matrix.duckdb_arch }}-ccache-${{ steps.ccache_timestamp.outputs.timestamp }}
+          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ steps.ccache_timestamp.outputs.timestamp }}
           restore-keys: |
-            ${{ matrix.duckdb_arch }}-ccache-
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-
 
       - name: Build extension
         run: |
@@ -242,11 +242,6 @@ jobs:
         if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test
-
-      # FIXME: ccache appears to be not working yet
-      - name: log ccache size
-        run: |
-          du -h -d 1 ccache_dir
 
       - uses: actions/upload-artifact@v3
         with:
@@ -303,7 +298,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@main
         continue-on-error: true
         with:
-          key: ${{ github.job }}-${{ matrix.duckdb_arch }}
+          key: extension-distribution-${{ matrix.duckdb_arch }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           docker run \
             -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
-            -e TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }} \
+            -e TOOLCHAIN_FLAGS='${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}' \
             -v .:/duckdb_build_dir \
             duckdb/${{ matrix.duckdb_arch }} \
             make release

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -216,15 +216,24 @@ jobs:
           echo "DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}" >> docker_env.txt
           echo "TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}" >> docker_env.txt
 
+      - name: Prepare ccache timestamp
+        shell: cmake -P {0}
+        id: ccache_timestamp
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
       - name: Create ccache dirs
         run: |
           touch ./ccache-dir
 
-      - name: Configure cache for ccache
-        uses: actions/cache@v4
+      - name: ccache cache files
+        uses: actions/cache@v1.1.0
         with:
           path: ./ccache-dir
-          key: ${{ github.job }}-${{ matrix.duckdb_arch }}
+          key: ${{ matrix.duckdb_arch }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ matrix.duckdb_arch }}-ccache-
 
       - name: Build extension
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -243,10 +243,10 @@ jobs:
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test
 
-      - name: debug step
+      # FIXME: ccache appears to be not working yet
+      - name: log ccache size
         run: |
-          ls ccache_dir
-          tree ccache_dir
+          du -h -d 1 ccache_dir
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -165,85 +165,6 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
-      ###
-      # Setup environment (TODO: this should ideally be part of a container image)
-      ###
-      - name: Install required ubuntu packages
-        if: ${{ matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64' }}
-        run: |
-          apt-get update -y -qq
-          apt-get install -y -qq software-properties-common
-          apt-get install -y -qq --fix-missing ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client pkg-config
-
-      - name: Install required manylinux packages
-        if: ${{ matrix.duckdb_arch == 'linux_amd64_gcc4' }}
-        run: |
-          yum install -y epel-release -y pkgconfig
-
-      - name: Install cross compiler for linux_arm64
-        shell: bash
-        if: ${{ matrix.duckdb_arch == 'linux_arm64' }}
-        run: |
-          apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-
-      - name: Install Git 2.18.5
-        if: ${{ matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64' }}
-        run: |
-          wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz
-          tar xvf v2.18.5.tar.gz
-          cd git-2.18.5
-          make
-          make prefix=/usr install
-          git --version
-
-      - name: Setup Rust
-        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && matrix.duckdb_arch == 'linux_amd64'}}
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Setup Rust for cross compilation
-        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && matrix.duckdb_arch == 'linux_arm64'}}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-unknown-linux-gnu
-
-      - name: Setup Rust for manylinux (dtolnay/rust-toolchain doesn't work due to curl being old here)
-        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && matrix.duckdb_arch == 'linux_amd64_gcc4' }}
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y 
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Install CMake 3.21
-        if: ${{ matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64' }}
-        shell: bash
-        run: |
-          wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.sh
-          chmod +x cmake-3.21.3-linux-x86_64.sh
-          ./cmake-3.21.3-linux-x86_64.sh --skip-license --prefix=/usr/local
-          cmake --version
-
-      - name: Install parser tools
-        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';parser_tools;') && (matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64') }}
-        run: |
-          apt-get install -y -qq bison flex
-
-      - name: Install parser tools (manylinux)
-        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';parser_tools;') && matrix.duckdb_arch == 'linux_amd64_gcc4'}}
-        run: |
-          yum install -y bison flex 
-
-      - name: Install fortran (amd64)
-        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';fortran;') && matrix.duckdb_arch == 'linux_amd64' }}
-        run: |
-          apt-get install -y -qq gfortran
-
-      - name: Install fortran (arm64)
-        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';fortran;') && matrix.duckdb_arch == 'linux_arm64' }}
-        run: |
-          apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu
-
-      ###
-      # Checkin out repositories
-      ###
       - uses: actions/checkout@v3
         name: Checkout override repository
         if: ${{inputs.override_repository != ''}}
@@ -265,11 +186,6 @@ jobs:
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
 
-      - name: Setup ManyLinux2014
-        if: ${{ matrix.duckdb_arch == 'linux_amd64_gcc4' }}
-        run: |
-          ./duckdb/scripts/setup_manylinux2014.sh general ccache ssh python_alias openssl
-
       - uses: actions/checkout@v3
         name: Checkout Extension CI tools
         if: ${{inputs.override_ci_tools_ref != ''}}
@@ -280,46 +196,24 @@ jobs:
           fetch-depth: 0
 
       ###
-      # Runtime configuration before build
+      # Build Docker image using the dockerfile from the extension-ci-tools
       ###
-      - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11 # Note: pinned due to GLIBC incompatibility in later releases
-        continue-on-error: true
-        with:
-          key: ${{ github.job }}-${{ matrix.duckdb_arch }}
-
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11.1
-        with:
-          vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
-          vcpkgGitURL: ${{ inputs.vcpkg_url }}
-
-      - name: Configure OpenSSL for Rust
-        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
-        run: |
-          echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
-          echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
-          echo "OPENSSL_USE_STATIC_LIBS=true" >> $GITHUB_ENV
-
-      ###
-      # Custom toolchain script
-      ###
-      - name: Run custom toolchain script
-        if: ${{ inputs.custom_toolchain_script }}
+      - name: Build Docker image
         shell: bash
         run: |
-          bash scripts/setup-custom-toolchain.sh
+          docker build -t duckdb/${{ matrix.duckdb_arch }} ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
 
       ###
       # Building & testing
       ###
       - name: Build extension
-        env:
-          GEN: ninja
-          TOOLCHAIN_FLAGS: ${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}
-          DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
         run: |
-          make release
+          docker run -it \
+            -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
+            -e TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }} \
+            -v ~/Development/extension-template:/duckdb_extension \
+            duckdb/${{ matrix.duckdb_arch }} \
+            make release
 
       - name: Test extension
         if: ${{ matrix.duckdb_arch != 'linux_arm64'}}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -161,7 +161,6 @@ jobs:
       GEN: ninja
       BUILD_SHELL: ${{ inputs.build_duckdb_shell && '1' || '0' }}
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -231,7 +231,7 @@ jobs:
         uses: actions/cache@v1.1.0
         with:
           path: ./ccache-dir
-          key: ${{ matrix.duckdb_arch }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          key: ${{ matrix.duckdb_arch }}-ccache-${{ steps.ccache_timestamp.outputs.timestamp }}
           restore-keys: |
             ${{ matrix.duckdb_arch }}-ccache-
 

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -199,7 +199,22 @@ jobs:
         run: |
           docker build -t duckdb/${{ matrix.duckdb_arch }} ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
 
-      - name: Build & test extension
+      - name: Build extension
+        run: |
+          docker run \
+            -e VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \
+            -e BUILD_SHELL=${{ inputs.build_duckdb_shell && '1' || '0' }} \
+            -e OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
+            -e OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
+            -e OPENSSL_USE_STATIC_LIBS=true \
+            -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
+            -e TOOLCHAIN_FLAGS='${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}' \
+            -v .:/duckdb_build_dir \
+            duckdb/${{ matrix.duckdb_arch }} \
+            make release
+
+      - name: Test extension
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
         run: |
           docker run \
             -e VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -224,12 +224,12 @@ jobs:
 
       - name: Create ccache dirs
         run: |
-          touch ./ccache-dir
+          touch ./ccache_dir
 
       - name: ccache cache files
         uses: actions/cache@v4
         with:
-          path: ./ccache-dir
+          path: ./ccache_dir
           key: ${{ matrix.duckdb_arch }}-ccache-${{ steps.ccache_timestamp.outputs.timestamp }}
           restore-keys: |
             ${{ matrix.duckdb_arch }}-ccache-

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -203,7 +203,7 @@ jobs:
         run: |
           docker run \
             -e OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
-            -e OPENSSL_DIR=`pwd`/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
+            -e OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
             -e OPENSSL_USE_STATIC_LIBS=true \
             -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
             -e TOOLCHAIN_FLAGS='${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}' \

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -207,17 +207,18 @@ jobs:
 
       - name: Set up environment variables to be passed to docker
         run: |
-          echo "DOCKER_ENV_VARS=-e VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \
-          -e BUILD_SHELL=${{ inputs.build_duckdb_shell && '1' || '0' }} \
-          -e OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
-          -e OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
-          -e OPENSSL_USE_STATIC_LIBS=true \
-          -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
-          -e TOOLCHAIN_FLAGS='${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}'" >> $GITHUB_ENV
+          touch docker_env.txt
+          echo "VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }}" >> docker_env.txt 
+          echo "BUILD_SHELL=${{ inputs.build_duckdb_shell && '1' || '0' }}" >> docker_env.txt
+          echo "OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> docker_env.txt
+          echo "OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> docker_env.txt
+          echo "OPENSSL_USE_STATIC_LIBS=true" >> docker_env.txt
+          echo "DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}" >> docker_env.txt
+          echo "TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}" >> docker_env.txt
 
       - name: Build extension
         run: |
-          docker run ${{ env.DOCKER_ENV_VARS }} \ 
+          docker --env-file docker_env.txt \ 
             -v .:/duckdb_build_dir \
             duckdb/${{ matrix.duckdb_arch }} \
             make release
@@ -225,7 +226,7 @@ jobs:
       - name: Test extension
         if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
         run: |
-          docker run ${{ env.DOCKER_ENV_VARS }} \
+          docker run --env-file docker_env.txt \
             -v .:/duckdb_build_dir \
             duckdb/${{ matrix.duckdb_arch }} \
             make test

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -225,6 +225,7 @@ jobs:
       - name: Create ccache dirs
         run: |
           touch ./ccache_dir
+          chmod 755 ./ccache_dir
 
       - name: ccache cache files
         uses: actions/cache@v4

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -198,8 +198,8 @@ jobs:
         shell: bash
         run: |
           docker build \
-            --build-arg 'extra_toolchains=${{ inputs.extra_toolchains }}'
-            --build-arg 'enable_rust=${{ inputs.enable_rust && '1' || '0' }}'
+            --build-arg 'extra_toolchains=${{ inputs.extra_toolchains }}' \
+            --build-arg 'enable_rust=${{ inputs.enable_rust && '1' || '0' }}' \
             -t duckdb/${{ matrix.duckdb_arch }} \
             ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
 

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -207,7 +207,7 @@ jobs:
       ###
       - name: Build extension
         run: |
-          docker run -it \
+          docker run \
             -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
             -e TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }} \
             -v ~/Development/extension-template:/duckdb_extension \
@@ -217,7 +217,12 @@ jobs:
       - name: Test extension
         if: ${{ matrix.duckdb_arch != 'linux_arm64'}}
         run: |
-          make test
+          docker run \
+            -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
+            -e TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }} \
+            -v ~/Development/extension-template:/duckdb_extension \
+            duckdb/${{ matrix.duckdb_arch }} \
+            make test
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -202,8 +202,8 @@ jobs:
       - name: Build extension
         run: |
           docker run \
-            -e OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
-            -e OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
+            -e OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
+            -e OPENSSL_DIR=`pwd`/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
             -e OPENSSL_USE_STATIC_LIBS=true \
             -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
             -e TOOLCHAIN_FLAGS='${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}' \

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -194,17 +194,11 @@ jobs:
           repository: ${{ inputs.override_ci_tools_repository }}
           fetch-depth: 0
 
-      ###
-      # Build Docker image using the dockerfile from the extension-ci-tools
-      ###
       - name: Build Docker image
         shell: bash
         run: |
           docker build -t duckdb/${{ matrix.duckdb_arch }} ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
 
-      ###
-      # Building & testing
-      ###
       - name: Build extension
         run: |
           docker run \

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -200,8 +200,7 @@ jobs:
           docker build \
             --build-arg 'vcpkg_url=${{ inputs.vcpkg_url }}' \
             --build-arg 'vcpkg_commit=${{ inputs.vcpkg_commit }}' \
-            --build-arg 'extra_toolchains=${{ format(';{0};', inputs.extra_toolchains) }}' \
-            --build-arg 'enable_rust=${{ inputs.enable_rust && '1' || '0' }}' \
+            --build-arg 'extra_toolchains=${{ inputs.enable_rust  && format(';{0};rust;', inputs.extra_toolchains) || format(';{0};', inputs.extra_toolchains) }}' \
             -t duckdb/${{ matrix.duckdb_arch }} \
             ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
 

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -222,17 +222,18 @@ jobs:
 
       - name: Build extension
         run: |
-          docker run --env-file docker_env.txt \ 
-            -v .:/duckdb_build_dir \
-            -v ./ccache_dir:/ccache_dir \
+          docker run --env-file=docker_env.txt \ 
+            -v `pwd`:/duckdb_build_dir \
+            -v `pwd`/ccache_dir:/ccache_dir \
             duckdb/${{ matrix.duckdb_arch }} \
             make release
 
       - name: Test extension
         if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
         run: |
-          docker run --env-file docker_env.txt \
-            -v .:/duckdb_build_dir \
+          docker run --env-file=docker_env.txt \ 
+            -v `pwd`:/duckdb_build_dir \
+            -v `pwd`/ccache_dir:/ccache_dir \
             duckdb/${{ matrix.duckdb_arch }} \
             make test
 

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -96,7 +96,7 @@ jobs:
       osx_matrix: ${{ steps.set-matrix-osx.outputs.osx_matrix }}
       wasm_matrix: ${{ steps.set-matrix-wasm.outputs.wasm_matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout override repository
         if: ${{inputs.override_repository != ''}}
         with:
@@ -105,7 +105,7 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout current repository
         if: ${{inputs.override_repository == ''}}
         with:
@@ -164,7 +164,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout override repository
         if: ${{inputs.override_repository != ''}}
         with:
@@ -173,7 +173,7 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout current repository
         if: ${{inputs.override_repository == ''}}
         with:
@@ -185,7 +185,7 @@ jobs:
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Extension CI tools
         if: ${{inputs.override_ci_tools_ref != ''}}
         with:
@@ -240,7 +240,7 @@ jobs:
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout override repository
         if: ${{inputs.override_repository != ''}}
         with:
@@ -249,7 +249,7 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout current repository
         if: ${{inputs.override_repository == ''}}
         with:
@@ -270,7 +270,7 @@ jobs:
         with:
           python-version: '3.11'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Extension CI tools
         if: ${{inputs.override_ci_tools_ref != ''}}
         with:
@@ -369,7 +369,7 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout override repository
         if: ${{inputs.override_repository != ''}}
         with:
@@ -378,7 +378,7 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout current repository
         if: ${{inputs.override_repository == ''}}
         with:
@@ -405,7 +405,7 @@ jobs:
           update-rtools: true
           rtools-version: '42' # linker bug in 43
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Extension CI tools
         if: ${{inputs.override_ci_tools_ref != ''}}
         with:
@@ -464,7 +464,7 @@ jobs:
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout override repository
         if: ${{inputs.override_repository != ''}}
         with:
@@ -473,14 +473,14 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout current repository
         if: ${{inputs.override_repository == ''}}
         with:
           fetch-depth: 0
           submodules: 'true'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Extension CI tools
         if: ${{inputs.override_ci_tools_ref != ''}}
         with:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -222,20 +222,12 @@ jobs:
 
       - name: Build extension
         run: |
-          docker run --env-file=docker_env.txt \ 
-            -v `pwd`:/duckdb_build_dir \
-            -v `pwd`/ccache_dir:/ccache_dir \
-            duckdb/${{ matrix.duckdb_arch }} \
-            make release
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make release
 
       - name: Test extension
         if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
         run: |
-          docker run --env-file=docker_env.txt \ 
-            -v `pwd`:/duckdb_build_dir \
-            -v `pwd`/ccache_dir:/ccache_dir \
-            duckdb/${{ matrix.duckdb_arch }} \
-            make test
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test
 
       - name: debug step
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -202,6 +202,9 @@ jobs:
       - name: Build extension
         run: |
           docker run \
+            -e OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
+            -e OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }} \
+            -e OPENSSL_USE_STATIC_LIBS=true \
             -e DUCKDB_PLATFORM=${{ matrix.duckdb_arch }} \
             -e TOOLCHAIN_FLAGS='${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}' \
             -v .:/duckdb_build_dir \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+# DuckDB docker images
+DuckDB uses Docker images to build linux binaries in a flexible and reproducible way. These images can be used 
+to compile a DuckDB binary (both extensions and the duckdb shell). To use an image, first build it:
+
+```shell
+docker build -t duckdb/linux_amd64_gcc4 ./docker/linux_amd64_gcc4
+```
+
+Then to start building your extension:
+```shell
+docker run -it -v <path_to_duckdb_or_extension>:/duckdb_build_dir duckdb/linux_amd64_gcc4 make 
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,11 @@ DuckDB uses Docker images to build linux binaries in a flexible and reproducible
 to compile a DuckDB binary (both extensions and the duckdb shell). To use an image, first build it:
 
 ```shell
-docker build -t duckdb/linux_amd64_gcc4 ./docker/linux_amd64_gcc4
+docker build \ 
+  --build-arg 'vcpkg_url=https://github.com/microsoft/vcpkg.git' \
+  --build-arg 'vcpkg_commit=a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6' \
+  -t duckdb/linux_amd64_gcc4 \ 
+  ./docker/linux_amd64_gcc4
 ```
 
 Then to start building your extension:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,16 +1,5 @@
 # DuckDB docker images
 DuckDB uses Docker images to build linux binaries in a flexible and reproducible way. These images can be used 
-to compile a DuckDB binary (both extensions and the duckdb shell). To use an image, first build it:
-
-```shell
-docker build \ 
-  --build-arg 'vcpkg_url=https://github.com/microsoft/vcpkg.git' \
-  --build-arg 'vcpkg_commit=a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6' \
-  -t duckdb/linux_amd64_gcc4 \ 
-  ./docker/linux_amd64_gcc4
-```
-
-Then to start building your extension:
-```shell
-docker run -it -v <path_to_duckdb_or_extension>:/duckdb_build_dir duckdb/linux_amd64_gcc4 make 
-```
+to compile a DuckDB binary (both extensions and the duckdb shell). For more details on how to use these Dockerfiles,
+check out the `.github/workflows/_extension_distribution.yml` workflow, which invokes the dockerfiles as part of the 
+build process.

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -48,6 +48,9 @@ WORKDIR /duckdb_build_dir
 # Mount for ccache to allow restoring ccache in GH actions
 VOLUME /ccache_dir
 ENV CCACHE_DIR=/ccache_dir
+ENV CCACHE_COMPRESS=TRUE
+ENV CCACHE_COMPRESSLEVEL=6
+ENV CCACHE_MAXSIZE=400M
 
 ###
 # Conditionally configure some extra dependencies

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -45,6 +45,10 @@ ENV GEN=ninja
 VOLUME /duckdb_build_dir
 WORKDIR /duckdb_build_dir
 
+# Mount for ccache to allow restoring ccache in GH actions
+VOLUME /ccache_dir
+ENV CCACHE_DIR=/ccache_dir
+
 ###
 # Conditionally configure some extra dependencies
 ###

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -63,23 +63,23 @@ ARG enable_rust
 RUN echo "$extra_toolchains" > ~/extra_toolchains.txt
 
 # Install Parser tools
-RUN if [[ $extra_toolchains == *";parser-tools;"* ]]; then \
+RUN if [ "$extra_toolchains" == *";parser-tools;"* ]; then \
       apt-get install -y -qq bison flex; \
     fi
 
 # Install Fortran
-RUN if [[ $extra_toolchains == *";fortran;"* ]]; then \
+RUN if [ "$extra_toolchains" == *";fortran;"* ]; then \
       apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu; \
     fi
 
 # Configure Rust
-RUN if [[ $extra_toolchains == *";rust;"* ]] || [ "$enable_rust" = "1" ]; then \
+RUN if [ "$extra_toolchains" == *";rust;"* ] || [ "$enable_rust" = "1" ]; then \
       curl https://sh.rustup.rs -sSf | bash -s -- -y ;\
     fi
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Configure go
-RUN if [[ $extra_toolchains == *";go;"* ]]; then \
+RUN if [ "$extra_toolchains" == *";go;"* ]; then \
       apt-get install -y -qq golang-go; \
     fi
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:18.04
 
+###
+# Base image setup
+###
+
 # Setup the basic necessities
 RUN apt-get update -y -qq
 RUN apt-get install -y -qq software-properties-common
@@ -21,19 +25,6 @@ RUN wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz && \
     make && \
     make prefix=/usr install
 
-# Install cross compilation tools
-RUN apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-
-# Configure Parser tools
-RUN apt-get install -y -qq bison flex
-
-# Install fortran
-RUN apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu
-
-# Configure Rust
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
 RUN mkdir /vcpkg && \
     cd /vcpkg && \
@@ -51,3 +42,35 @@ ENV GEN=ninja
 # Specify where we expect the extension to be mounted and use that as working dir
 VOLUME /duckdb_build_dir
 WORKDIR /duckdb_build_dir
+
+###
+# Conditionally configure some extra dependencies
+###
+# a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
+# Note that it should start and end with a `;`
+ARG extra_toolchains
+ARG enable_rust
+
+RUN echo "$extra_toolchains" > ~/extra_toolchains.txt
+
+# Install Parser tools
+RUN if [[ $extra_toolchains == *";parser-tools;"* ]]; then \
+      apt-get install -y -qq bison flex; \
+    fi
+
+# Install Fortran
+RUN if [[ $extra-toolchains == *";fortran;"* ]]; then \
+      apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu; \
+    fi
+
+# Configure Rust
+RUN if [[ $extra_toolchains == *";rust;"* ]] || [ "$enable_rust" = "1" ]; then \
+      curl https://sh.rustup.rs -sSf | bash -s -- -y ;\
+    fi
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Configure go
+RUN if [[ $extra_toolchains == *";go;"* ]]; then \
+      apt-get install -y -qq golang-go; \
+    fi
+ENV PATH="/usr/local/go/bin:${PATH}"

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -47,8 +47,7 @@ WORKDIR /duckdb_build_dir
 
 # Mount for ccache to allow restoring ccache in GH actions
 VOLUME /ccache_dir
-ENV CCACHE_BASE_DIR=/ccache_dir
-ENV CCACHE_DIR=/ccache_dir/.ccache
+ENV CCACHE_DIR=/ccache_dir
 ENV CCACHE_COMPRESS=TRUE
 ENV CCACHE_COMPRESSLEVEL=6
 ENV CCACHE_MAXSIZE=400M

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -57,14 +57,14 @@ ENV CCACHE_MAXSIZE=400M
 # Conditionally configure some extra dependencies
 ###
 # a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
-# Note that it should start and end with a `;` e.g. `;rust;parser-tools;`
+# Note that it should start and end with a `;` e.g. `;rust;parser_tools;`
 ARG extra_toolchains
 
 # NOTE: the weird case conditionals are because of bash limitations in the ubuntu image used (see https://stackoverflow.com/questions/229551/how-to-check-if-a-string-contains-a-substring-in-bash)
 
 # Install Parser tools
 RUN case "$extra_toolchains" in \
-  *\;parser-tools\;*) \
+  *\;parser_tools\;*) \
     apt-get install -y -qq bison flex \
   ;; \
 esac

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y -qq --fix-missing ninja-build make gcc-multilib g++-multi
 RUN apt-get install -y -qq ccache
 
 # Install cmake 3.21
-RUN mdir /cmake_3_21 && \
+RUN mkdir /cmake_3_21 && \
     cd /cmake_3_21 && \
     wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.sh && \
     chmod +x cmake-3.21.3-linux-x86_64.sh && \

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -14,6 +14,13 @@ RUN mkdir /cmake_3_21 && \
     ./cmake-3.21.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
     cmake --version
 
+# Install GIT
+RUN wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz
+    tar xvf v2.18.5.tar.gz && \
+    cd git-2.18.5 && \
+    make && \
+    make prefix=/usr install
+
 # Install cross compilation tools
 RUN apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -58,28 +58,35 @@ ENV CCACHE_MAXSIZE=400M
 # a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
 # Note that it should start and end with a `;`
 ARG extra_toolchains
-ARG enable_rust
 
-RUN echo "$extra_toolchains" > ~/extra_toolchains.txt
+# NOTE: the weird case conditionals are because of bash limitations in the ubuntu image used (see https://stackoverflow.com/questions/229551/how-to-check-if-a-string-contains-a-substring-in-bash)
 
 # Install Parser tools
-RUN if [ "$extra_toolchains" == *";parser-tools;"* ]; then \
-      apt-get install -y -qq bison flex; \
-    fi
+RUN case "$extra_toolchains" in \
+  *\;parser-tools\;*) \
+    apt-get install -y -qq bison flex \
+  ;; \
+esac
 
 # Install Fortran
-RUN if [ "$extra_toolchains" == *";fortran;"* ]; then \
-      apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu; \
-    fi
+RUN case "$extra_toolchains" in \
+  *\;fortran\;*) \
+    apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu \
+  ;; \
+esac
 
 # Configure Rust
-RUN if [ "$extra_toolchains" == *";rust;"* ] || [ "$enable_rust" = "1" ]; then \
-      curl https://sh.rustup.rs -sSf | bash -s -- -y ;\
-    fi
+RUN case "$extra_toolchains" in \
+  *\;rust\;*) \
+    curl https://sh.rustup.rs -sSf | bash -s -- -y \
+  ;; \
+esac
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Configure go
-RUN if [ "$extra_toolchains" == *";go;"* ]; then \
-      apt-get install -y -qq golang-go; \
-    fi
+RUN case "$extra_toolchains" in \
+  *\;go\;*) \
+    capt-get install -y -qq golang-go \
+  ;; \
+esac \
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -26,12 +26,14 @@ RUN wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz && \
     make prefix=/usr install
 
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
+ARG vcpkg_url
+ARG vcpkg_commit
 RUN mkdir /vcpkg && \
     cd /vcpkg && \
     git init && \
-    git remote add origin https://github.com/Microsoft/vcpkg.git && \
-    git fetch origin a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6 && \
-    git checkout a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6 && \
+    git remote add origin $vcpkg_url && \
+    git fetch origin $vcpkg_commit && \
+    git checkout $vcpkg_commit && \
     ./bootstrap-vcpkg.sh
 ENV VCPKG_ROOT=/vcpkg
 ENV VCPKG_TOOLCHAIN_PATH=/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -47,7 +47,8 @@ WORKDIR /duckdb_build_dir
 
 # Mount for ccache to allow restoring ccache in GH actions
 VOLUME /ccache_dir
-ENV CCACHE_DIR=/ccache_dir
+ENV CCACHE_BASE_DIR=/ccache_dir
+ENV CCACHE_DIR=/ccache_dir/.ccache
 ENV CCACHE_COMPRESS=TRUE
 ENV CCACHE_COMPRESSLEVEL=6
 ENV CCACHE_MAXSIZE=400M

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:18.04
+
+# Setup the basic necessities
+RUN apt-get update -y -qq
+RUN apt-get install -y -qq software-properties-common
+RUN apt-get install -y -qq --fix-missing ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client pkg-config
+RUN apt-get install -y -qq ccache
+
+# Install cmake 3.21
+RUN mdir /cmake_3_21 && \
+    cd /cmake_3_21 && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.sh && \
+    chmod +x cmake-3.21.3-linux-x86_64.sh && \
+    ./cmake-3.21.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
+    cmake --version
+
+# Install cross compilation tools
+RUN apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+# Configure Parser tools
+RUN apt-get install -y -qq bison flex
+
+# Install fortran
+RUN apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu
+
+# Configure Rust
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup toolchain install aarch64-unknown-linux-gnu
+
+# Setup VCPKG n a mounted volume TODO: figure out how to cache this
+RUN mkdir /vcpkg && \
+    cd /vcpkg && \
+    git init && \
+    git remote add origin https://github.com/Microsoft/vcpkg.git && \
+    git fetch origin a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6 && \
+    git checkout a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6 && \
+    ./bootstrap-vcpkg.sh
+ENV VCPKG_ROOT=/vcpkg
+ENV VCPKG_TOOLCHAIN_PATH=/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+# Common environment variables
+ENV GEN=ninja
+
+# Specify where we expect the extension to be mounted and use that as working dir
+VOLUME /duckdb_build_dir
+WORKDIR /duckdb_build_dir

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu
 # Configure Rust
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup target add aarch64-unknown-linux-gnu
 
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
 RUN mkdir /vcpkg && \

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu
 # Configure Rust
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup toolchain install aarch64-unknown-linux-gnu
+RUN rustup target add aarch64-unknown-linux-gnu
 
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
 RUN mkdir /vcpkg && \

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -86,7 +86,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # Configure go
 RUN case "$extra_toolchains" in \
   *\;go\;*) \
-    capt-get install -y -qq golang-go \
+    apt-get install -y -qq golang-go \
   ;; \
-esac \
+esac
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -65,7 +65,7 @@ RUN if [[ $extra_toolchains == *";parser-tools;"* ]]; then \
     fi
 
 # Install Fortran
-RUN if [[ $extra-toolchains == *";fortran;"* ]]; then \
+RUN if [[ $extra_toolchains == *";fortran;"* ]]; then \
       apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu; \
     fi
 

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -56,7 +56,7 @@ ENV CCACHE_MAXSIZE=400M
 # Conditionally configure some extra dependencies
 ###
 # a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
-# Note that it should start and end with a `;`
+# Note that it should start and end with a `;` e.g. `;rust;parser-tools;`
 ARG extra_toolchains
 
 # NOTE: the weird case conditionals are because of bash limitations in the ubuntu image used (see https://stackoverflow.com/questions/229551/how-to-check-if-a-string-contains-a-substring-in-bash)

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir /cmake_3_21 && \
     cmake --version
 
 # Install GIT
-RUN wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz
+RUN wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz && \
     tar xvf v2.18.5.tar.gz && \
     cd git-2.18.5 && \
     make && \

--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -39,8 +39,7 @@ WORKDIR /duckdb_build_dir
 
 # Mount for ccache to allow restoring ccache in GH actions
 VOLUME /ccache_dir
-ENV CCACHE_BASE_DIR=/ccache_dir
-ENV CCACHE_DIR=/ccache_dir/.ccache
+ENV CCACHE_DIR=/ccache_dir
 ENV CCACHE_COMPRESS=TRUE
 ENV CCACHE_COMPRESSLEVEL=6
 ENV CCACHE_MAXSIZE=400M

--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -1,0 +1,43 @@
+FROM quay.io/pypa/manylinux2014_x86_64:latest
+
+RUN yum install -y epel-release -y pkgconfig
+
+# TODO do we need this?
+RUN git config --global --add safe.directory '*'
+
+# TODO do we need these?
+RUN yum install -y gcc-c++
+RUN yum install -y nodejs
+
+# Setup the basic necessities
+RUN yum install -y curl zip unzip tar
+RUN yum install -y ninja-build
+RUN yum install -y perl-IPC-Cmd
+RUN yum install -y ccache
+RUN yum install -y java-11-openjdk-devel maven
+RUN yum install -y libgcc*i686 libstdc++*i686 glibc*i686 libgfortran*i686
+
+# Configure Parser tools
+RUN yum install -y bison flex
+
+# Configure Rust
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Setup VCPKG n a mounted volume TODO: figure out how to cache this
+RUN mkdir /vcpkg && \
+    cd /vcpkg && \
+    git init && \
+    git remote add origin https://github.com/Microsoft/vcpkg.git && \
+    git fetch origin a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6 && \
+    git checkout a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6 && \
+    ./bootstrap-vcpkg.sh
+ENV VCPKG_ROOT=/vcpkg
+ENV VCPKG_TOOLCHAIN_PATH=/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+# Common environment variables
+ENV GEN=ninja
+
+# Specify where we expect the extension to be mounted and use that as working dir
+VOLUME /duckdb_build_dir
+WORKDIR /duckdb_build_dir

--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -50,7 +50,6 @@ ENV CCACHE_MAXSIZE=400M
 # a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
 # Note that it should start and end with a `;`
 ARG extra_toolchains
-ARG enable_rust
 
 RUN echo "$extra_toolchains" > ~/extra_toolchains.txt
 

--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -18,12 +18,14 @@ RUN yum install -y java-11-openjdk-devel maven
 RUN yum install -y libgcc*i686 libstdc++*i686 glibc*i686 libgfortran*i686
 
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
+ARG vcpkg_url
+ARG vcpkg_commit
 RUN mkdir /vcpkg && \
     cd /vcpkg && \
     git init && \
-    git remote add origin https://github.com/Microsoft/vcpkg.git && \
-    git fetch origin a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6 && \
-    git checkout a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6 && \
+    git remote add origin $vcpkg_url && \
+    git fetch origin $vcpkg_commit && \
+    git checkout $vcpkg_commit && \
     ./bootstrap-vcpkg.sh
 ENV VCPKG_ROOT=/vcpkg
 ENV VCPKG_TOOLCHAIN_PATH=/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -39,7 +39,8 @@ WORKDIR /duckdb_build_dir
 
 # Mount for ccache to allow restoring ccache in GH actions
 VOLUME /ccache_dir
-ENV CCACHE_DIR=/ccache_dir
+ENV CCACHE_BASE_DIR=/ccache_dir
+ENV CCACHE_DIR=/ccache_dir/.ccache
 ENV CCACHE_COMPRESS=TRUE
 ENV CCACHE_COMPRESSLEVEL=6
 ENV CCACHE_MAXSIZE=400M

--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -48,7 +48,7 @@ ENV CCACHE_MAXSIZE=400M
 # Conditionally configure some extra dependencies
 ###
 # a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
-# Note that it should start and end with a `;`
+# Note that it should start and end with a `;` e.g. `;rust;parser-tools;`
 ARG extra_toolchains
 
 RUN echo "$extra_toolchains" > ~/extra_toolchains.txt

--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -49,13 +49,13 @@ ENV CCACHE_MAXSIZE=400M
 # Conditionally configure some extra dependencies
 ###
 # a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
-# Note that it should start and end with a `;` e.g. `;rust;parser-tools;`
+# Note that it should start and end with a `;` e.g. `;rust;parser_tools;`
 ARG extra_toolchains
 
 RUN echo "$extra_toolchains" > ~/extra_toolchains.txt
 
 # Install Parser tools
-RUN if [[ $extra_toolchains == *";parser-tools;"* ]]; then \
+RUN if [[ $extra_toolchains == *";parser_tools;"* ]]; then \
       yum install -y bison flex;\
     fi
 

--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -37,6 +37,10 @@ ENV GEN=ninja
 VOLUME /duckdb_build_dir
 WORKDIR /duckdb_build_dir
 
+# Mount for ccache to allow restoring ccache in GH actions
+VOLUME /ccache_dir
+ENV CCACHE_DIR=/ccache_dir
+
 ###
 # Conditionally configure some extra dependencies
 ###

--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -40,6 +40,9 @@ WORKDIR /duckdb_build_dir
 # Mount for ccache to allow restoring ccache in GH actions
 VOLUME /ccache_dir
 ENV CCACHE_DIR=/ccache_dir
+ENV CCACHE_COMPRESS=TRUE
+ENV CCACHE_COMPRESSLEVEL=6
+ENV CCACHE_MAXSIZE=400M
 
 ###
 # Conditionally configure some extra dependencies

--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -17,13 +17,6 @@ RUN yum install -y ccache
 RUN yum install -y java-11-openjdk-devel maven
 RUN yum install -y libgcc*i686 libstdc++*i686 glibc*i686 libgfortran*i686
 
-# Configure Parser tools
-RUN yum install -y bison flex
-
-# Configure Rust
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
 RUN mkdir /vcpkg && \
     cd /vcpkg && \
@@ -41,3 +34,32 @@ ENV GEN=ninja
 # Specify where we expect the extension to be mounted and use that as working dir
 VOLUME /duckdb_build_dir
 WORKDIR /duckdb_build_dir
+
+###
+# Conditionally configure some extra dependencies
+###
+# a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
+# Note that it should start and end with a `;`
+ARG extra_toolchains
+ARG enable_rust
+
+RUN echo "$extra_toolchains" > ~/extra_toolchains.txt
+
+# Install Parser tools
+RUN if [[ $extra_toolchains == *";parser-tools;"* ]]; then \
+      yum install -y bison flex;\
+    fi
+
+# Configure Rust
+RUN if [[ $extra_toolchains == *";rust;"* ]] || [ "$enable_rust" = "1" ]; then \
+      curl https://sh.rustup.rs -sSf | bash -s -- -y ;\
+    fi
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Configure go
+RUN if [[ $extra_toolchains == *";go;"* ]]; then \
+      yum install -y wget; \
+      wget https://go.dev/dl/go1.23.1.linux-amd64.tar.gz; \
+      tar -C /usr/local -xzf go1.23.1.linux-amd64.tar.gz; \
+fi
+ENV PATH="/usr/local/go/bin:${PATH}"

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -6,6 +6,9 @@ RUN apt-get install -y -qq software-properties-common
 RUN apt-get install -y -qq --fix-missing ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client pkg-config
 RUN apt-get install -y -qq ccache
 
+# Setup cross compiler because GH actions does not have open source arm runners yet
+RUN apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
 # Install cmake 3.21
 RUN mkdir /cmake_3_21 && \
     cd /cmake_3_21 && \

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -47,6 +47,9 @@ WORKDIR /duckdb_build_dir
 # Mount for ccache to allow restoring ccache in GH actions
 VOLUME /ccache_dir
 ENV CCACHE_DIR=/ccache_dir
+ENV CCACHE_COMPRESS=TRUE
+ENV CCACHE_COMPRESSLEVEL=6
+ENV CCACHE_MAXSIZE=400M
 
 ###
 # Conditionally configure some extra dependencies

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -55,7 +55,7 @@ ENV CCACHE_MAXSIZE=400M
 # Conditionally configure some extra dependencies
 ###
 # a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
-# Note that it should start and end with a `;`
+# Note that it should start and end with a `;` e.g. `;rust;parser-tools;`
 ARG extra_toolchains
 
 # NOTE: the weird case conditionals are because of bash limitations in the ubuntu image used (see https://stackoverflow.com/questions/229551/how-to-check-if-a-string-contains-a-substring-in-bash)
@@ -75,13 +75,13 @@ RUN case "$extra_toolchains" in \
 esac
 
 # Configure Rust
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN case "$extra_toolchains" in \
   *\;rust\;*) \
     curl https://sh.rustup.rs -sSf | bash -s -- -y; \
     rustup target add aarch64-unknown-linux-gnu \
   ;; \
 esac
-ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Configure go
 RUN case "$extra_toolchains" in \
@@ -89,4 +89,3 @@ RUN case "$extra_toolchains" in \
     apt-get install -y -qq golang-go \
   ;; \
 esac
-ENV PATH="/usr/local/go/bin:${PATH}"

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -14,6 +14,13 @@ RUN mkdir /cmake_3_21 && \
     ./cmake-3.21.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
     cmake --version
 
+# Install GIT
+RUN wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz
+    tar xvf v2.18.5.tar.gz && \
+    cd git-2.18.5 && \
+    make && \
+    make prefix=/usr install
+
 # Configure Parser tools
 RUN apt-get install -y -qq bison flex
 

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -56,14 +56,14 @@ ENV CCACHE_MAXSIZE=400M
 # Conditionally configure some extra dependencies
 ###
 # a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
-# Note that it should start and end with a `;` e.g. `;rust;parser-tools;`
+# Note that it should start and end with a `;` e.g. `;rust;parser_tools;`
 ARG extra_toolchains
 
 # NOTE: the weird case conditionals are because of bash limitations in the ubuntu image used (see https://stackoverflow.com/questions/229551/how-to-check-if-a-string-contains-a-substring-in-bash)
 
 # Install Parser tools
 RUN case "$extra_toolchains" in \
-  *\;parser-tools\;*) \
+  *\;parser_tools\;*) \
     apt-get install -y -qq bison flex \
   ;; \
 esac

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -62,23 +62,23 @@ ARG enable_rust
 RUN echo "$extra_toolchains" > ~/extra_toolchains.txt
 
 # Install Parser tools
-RUN if [[ $extra_toolchains == *";parser-tools;"* ]]; then \
+RUN if [ "$extra_toolchains" == *";parser-tools;"* ]; then \
       apt-get install -y -qq bison flex; \
     fi
 
 # Install Fortran
-RUN if [[ $extra_toolchains == *";fortran;"* ]]; then \
+RUN if [ "$extra_toolchains" == *";fortran;"* ]; then \
       apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu; \
     fi
 
 # Configure Rust
-RUN if [[ $extra_toolchains == *";rust;"* ]] || [[ "$enable_rust" = "1" ]]; then \
+RUN if [ "$extra_toolchains" == *";rust;"* ] || [ "$enable_rust" = "1" ]; then \
       curl https://sh.rustup.rs -sSf | bash -s -- -y ;\
     fi
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Configure go
-RUN if [[ $extra_toolchains == *";go;"* ]]; then \
+RUN if [ "$extra_toolchains" == *";go;"* ]; then \
       apt-get install -y -qq golang-go; \
     fi
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -25,12 +25,14 @@ RUN wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz && \
     make prefix=/usr install
 
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
+ARG vcpkg_url
+ARG vcpkg_commit
 RUN mkdir /vcpkg && \
     cd /vcpkg && \
     git init && \
-    git remote add origin https://github.com/Microsoft/vcpkg.git && \
-    git fetch origin a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6 && \
-    git checkout a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6 && \
+    git remote add origin $vcpkg_url && \
+    git fetch origin $vcpkg_commit && \
+    git checkout $vcpkg_commit && \
     ./bootstrap-vcpkg.sh
 ENV VCPKG_ROOT=/vcpkg
 ENV VCPKG_TOOLCHAIN_PATH=/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -57,28 +57,35 @@ ENV CCACHE_MAXSIZE=400M
 # a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
 # Note that it should start and end with a `;`
 ARG extra_toolchains
-ARG enable_rust
 
-RUN echo "$extra_toolchains" > ~/extra_toolchains.txt
+# NOTE: the weird case conditionals are because of bash limitations in the ubuntu image used (see https://stackoverflow.com/questions/229551/how-to-check-if-a-string-contains-a-substring-in-bash)
 
 # Install Parser tools
-RUN if [ "$extra_toolchains" == *";parser-tools;"* ]; then \
-      apt-get install -y -qq bison flex; \
-    fi
+RUN case "$extra_toolchains" in \
+  *\;parser-tools\;*) \
+    apt-get install -y -qq bison flex \
+  ;; \
+esac
 
 # Install Fortran
-RUN if [ "$extra_toolchains" == *";fortran;"* ]; then \
-      apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu; \
-    fi
+RUN case "$extra_toolchains" in \
+  *\;fortran\;*) \
+    apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu \
+  ;; \
+esac
 
 # Configure Rust
-RUN if [ "$extra_toolchains" == *";rust;"* ] || [ "$enable_rust" = "1" ]; then \
-      curl https://sh.rustup.rs -sSf | bash -s -- -y ;\
-    fi
+RUN case "$extra_toolchains" in \
+  *\;rust\;*) \
+    curl https://sh.rustup.rs -sSf | bash -s -- -y \
+  ;; \
+esac
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Configure go
-RUN if [ "$extra_toolchains" == *";go;"* ]; then \
-      apt-get install -y -qq golang-go; \
-    fi
+RUN case "$extra_toolchains" in \
+  *\;go\;*) \
+    capt-get install -y -qq golang-go \
+  ;; \
+esac \
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -46,8 +46,7 @@ WORKDIR /duckdb_build_dir
 
 # Mount for ccache to allow restoring ccache in GH actions
 VOLUME /ccache_dir
-ENV CCACHE_BASE_DIR=/ccache_dir
-ENV CCACHE_DIR=/ccache_dir/.ccache
+ENV CCACHE_DIR=/ccache_dir
 ENV CCACHE_COMPRESS=TRUE
 ENV CCACHE_COMPRESSLEVEL=6
 ENV CCACHE_MAXSIZE=400M

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -44,6 +44,10 @@ ENV GEN=ninja
 VOLUME /duckdb_build_dir
 WORKDIR /duckdb_build_dir
 
+# Mount for ccache to allow restoring ccache in GH actions
+VOLUME /ccache_dir
+ENV CCACHE_DIR=/ccache_dir
+
 ###
 # Conditionally configure some extra dependencies
 ###

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y -qq --fix-missing ninja-build make gcc-multilib g++-multi
 RUN apt-get install -y -qq ccache
 
 # Install cmake 3.21
-RUN mdir /cmake_3_21 && \
+RUN mkdir /cmake_3_21 && \
     cd /cmake_3_21 && \
     wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.sh && \
     chmod +x cmake-3.21.3-linux-x86_64.sh && \

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:18.04
+
+# Setup the basic necessities
+RUN apt-get update -y -qq
+RUN apt-get install -y -qq software-properties-common
+RUN apt-get install -y -qq --fix-missing ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client pkg-config
+RUN apt-get install -y -qq ccache
+
+# Install cmake 3.21
+RUN mdir /cmake_3_21 && \
+    cd /cmake_3_21 && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.sh && \
+    chmod +x cmake-3.21.3-linux-x86_64.sh && \
+    ./cmake-3.21.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
+    cmake --version
+
+# Configure Parser tools
+RUN apt-get install -y -qq bison flex
+
+# Install fortran
+RUN apt-get install -y -qq gfortran
+
+# Configure Rust
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Setup VCPKG n a mounted volume TODO: figure out how to cache this
+RUN mkdir /vcpkg && \
+    cd /vcpkg && \
+    git init && \
+    git remote add origin https://github.com/Microsoft/vcpkg.git && \
+    git fetch origin a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6 && \
+    git checkout a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6 && \
+    ./bootstrap-vcpkg.sh
+ENV VCPKG_ROOT=/vcpkg
+ENV VCPKG_TOOLCHAIN_PATH=/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+# Common environment variables
+ENV GEN=ninja
+
+# Specify where we expect the extension to be mounted and use that as working dir
+VOLUME /duckdb_build_dir
+WORKDIR /duckdb_build_dir

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -46,7 +46,8 @@ WORKDIR /duckdb_build_dir
 
 # Mount for ccache to allow restoring ccache in GH actions
 VOLUME /ccache_dir
-ENV CCACHE_DIR=/ccache_dir
+ENV CCACHE_BASE_DIR=/ccache_dir
+ENV CCACHE_DIR=/ccache_dir/.ccache
 ENV CCACHE_COMPRESS=TRUE
 ENV CCACHE_COMPRESSLEVEL=6
 ENV CCACHE_MAXSIZE=400M

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -77,7 +77,8 @@ esac
 # Configure Rust
 RUN case "$extra_toolchains" in \
   *\;rust\;*) \
-    curl https://sh.rustup.rs -sSf | bash -s -- -y \
+    curl https://sh.rustup.rs -sSf | bash -s -- -y; \
+    rustup target add aarch64-unknown-linux-gnu \
   ;; \
 esac
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -24,17 +24,6 @@ RUN wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz && \
     make && \
     make prefix=/usr install
 
-# Configure Parser tools
-RUN apt-get install -y -qq bison flex
-
-# Install fortran
-RUN apt-get install -y -qq gfortran
-
-# Configure Rust
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup target add aarch64-unknown-linux-gnu
-
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
 RUN mkdir /vcpkg && \
     cd /vcpkg && \
@@ -52,3 +41,35 @@ ENV GEN=ninja
 # Specify where we expect the extension to be mounted and use that as working dir
 VOLUME /duckdb_build_dir
 WORKDIR /duckdb_build_dir
+
+###
+# Conditionally configure some extra dependencies
+###
+# a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
+# Note that it should start and end with a `;`
+ARG extra_toolchains
+ARG enable_rust
+
+RUN echo "$extra_toolchains" > ~/extra_toolchains.txt
+
+# Install Parser tools
+RUN if [[ $extra_toolchains == *";parser-tools;"* ]]; then \
+      apt-get install -y -qq bison flex; \
+    fi
+
+# Install Fortran
+RUN if [[ $extra-toolchains == *";fortran;"* ]]; then \
+      apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu; \
+    fi
+
+# Configure Rust
+RUN if [[ $extra_toolchains == *";rust;"* ]] || [ "$enable_rust" = "1" ]; then \
+      curl https://sh.rustup.rs -sSf | bash -s -- -y ;\
+    fi
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Configure go
+RUN if [[ $extra_toolchains == *";go;"* ]]; then \
+      apt-get install -y -qq golang-go; \
+    fi
+ENV PATH="/usr/local/go/bin:${PATH}"

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -85,7 +85,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # Configure go
 RUN case "$extra_toolchains" in \
   *\;go\;*) \
-    capt-get install -y -qq golang-go \
+    apt-get install -y -qq golang-go \
   ;; \
-esac \
+esac
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -64,12 +64,12 @@ RUN if [[ $extra_toolchains == *";parser-tools;"* ]]; then \
     fi
 
 # Install Fortran
-RUN if [[ $extra-toolchains == *";fortran;"* ]]; then \
+RUN if [[ $extra_toolchains == *";fortran;"* ]]; then \
       apt-get install -y -qq gfortran gfortran-aarch64-linux-gnu; \
     fi
 
 # Configure Rust
-RUN if [[ $extra_toolchains == *";rust;"* ]] || [ "$enable_rust" = "1" ]; then \
+RUN if [[ $extra_toolchains == *";rust;"* ]] || [[ "$enable_rust" = "1" ]]; then \
       curl https://sh.rustup.rs -sSf | bash -s -- -y ;\
     fi
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get install -y -qq gfortran
 # Configure Rust
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup target add aarch64-unknown-linux-gnu
 
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
 RUN mkdir /vcpkg && \

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir /cmake_3_21 && \
     cmake --version
 
 # Install GIT
-RUN wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz
+RUN wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz && \
     tar xvf v2.18.5.tar.gz && \
     cd git-2.18.5 && \
     make && \


### PR DESCRIPTION
This PR removes the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` flag from the Linux CI.

It achieves this by refactoring the linux jobs to manually invoke docker for the build and test steps effectively pulling out the github actions from the docker image. This has the following benefits:
- The jobs will not fail when GH stops supporting the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` flag
- easier to reproduce the environment locally
- more robust linux builds because we are not mixing github actions with a horribly old linux version anymore

Also during development I integrated https://github.com/duckdb/extension-ci-tools/pull/63 because I needed it, that saved me some CI cycles so I can just merge this PR and close the otherone.

There is quite some duplication between the dockerfiles, but I did not find a clean way to solve this yet, but any suggestions (or follow up PRs) are welcome ofc.

After this PR it makes sense to upstream this into duckdb/duckdb somehow because there we can reuse these images in CI as well to make things more robust and get rid of `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION`

Another follow up is to finally enable the vcpkg build cache, because that seems to be able to make quite a difference as well judging from how long vcpkg runs in the delta extension build
