### PR TITLE
force passing ci tools version

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -21,7 +21,7 @@ jobs:
       override_ref: main
       duckdb_version: v1.1.0
       override_ci_tools_repository: ${{ github.repository }}
-      override_ci_tools_ref: ${{ github.sha }}
+      ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp;go'
       custom_toolchain_script: true
 
@@ -33,7 +33,7 @@ jobs:
       override_repository: duckdb/duckdb_delta
       override_ref: 94f887bd539ec0d5ed0d31bd01ff3845cf378a9d
       override_ci_tools_repository: ${{ github.repository }}
-      override_ci_tools_ref: ${{ github.sha }}
+      ci_tools_version: ${{ github.sha }}
       duckdb_version: v1.1.0
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64'
       extra_toolchains: 'rust'

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -20,6 +20,11 @@ on:
       duckdb_version:
         required: true
         type: string
+      # The version of the https://github.com/duckdb/extension-ci-tools submodule of the extension. In most cases will be identical to `duckdb_version`.
+      # Passing this explicitly is required because of https://github.com/actions/toolkit/issues/1264
+      ci_tools_version:
+        required: true
+        type: string
       # ';' separated list of architectures to exclude, for example: 'linux_amd64;osx_arm64'
       exclude_archs:
         required: false
@@ -62,11 +67,6 @@ on:
         default: ""
       # Override the repo for the CI tools (for testing CI tools itself)
       override_ci_tools_repository:
-        required: false
-        type: string
-        default: ""
-      # Override the ref for the CI tools (for testing CI tools itself)
-      override_ci_tools_ref:
         required: false
         type: string
         default: ""
@@ -186,10 +186,9 @@ jobs:
 
       - uses: actions/checkout@v4
         name: Checkout Extension CI tools
-        if: ${{inputs.override_ci_tools_ref != ''}}
         with:
           path: 'extension-ci-tools'
-          ref: ${{ inputs.override_ci_tools_ref }}
+          ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
           fetch-depth: 0
 
@@ -305,10 +304,9 @@ jobs:
 
       - uses: actions/checkout@v4
         name: Checkout Extension CI tools
-        if: ${{inputs.override_ci_tools_ref != ''}}
         with:
           path: 'extension-ci-tools'
-          ref: ${{ inputs.override_ci_tools_ref }}
+          ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
           fetch-depth: 0
 
@@ -461,10 +459,9 @@ jobs:
 
       - uses: actions/checkout@v4
         name: Checkout Extension CI tools
-        if: ${{inputs.override_ci_tools_ref != ''}}
         with:
           path: 'extension-ci-tools'
-          ref: ${{ inputs.override_ci_tools_ref }}
+          ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
           fetch-depth: 0
 
@@ -546,10 +543,9 @@ jobs:
 
       - uses: actions/checkout@v4
         name: Checkout Extension CI tools
-        if: ${{inputs.override_ci_tools_ref != ''}}
         with:
           path: 'extension-ci-tools'
-          ref: ${{ inputs.override_ci_tools_ref }}
+          ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
           fetch-depth: 0
 


### PR DESCRIPTION
This PR aims to make calling the `.github/workflows/_extension_distribution.yml` workflow a little more predictable. It also fixes the CI failures that will happen whenever trying to build an extension on an old extension_ci_tools submodule after https://github.com/duckdb/extension-ci-tools/pull/79. 

What this means is that all extension will now be required to pass both a `duckdb_version` **and** a `ci_tools_version`. These will in most cases contain the same value (the tag of the latest stable release of duckdb or `main`).

The reason we need this is because we want to checkout the `extension_ci_tools` submodule of the extension to the version   of the called workflow. So for example in the following invocation of `_extension_distribution.yml`:
```yml
duckdb-stable-build:
    name: Build extension binaries
    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.1.0
    with:
      duckdb_version: v1.1.0
      extension_name: quack
```

What we would like to do automatically is to checkout the `extension_ci_tools` submodule to the `v1.1.0` tag that we pass to the workflow. However, due to https://github.com/actions/toolkit/issues/1264, this is actually ***ing difficult.

There are a few solutions here but all of them seem evil. The most sane way in my (and @carlopi's) opinion is to require explicitly passing the version as another tag, making it so that you need to pass the version 3(!) times:

```yml
duckdb-stable-build:
    name: Build extension binaries
    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.1.0
    with:
      duckdb_version: v1.1.0
      ci_tools_version: v1.1.0
      extension_name: quack
```

We have considered creating a single `target_version` input parameter but while nice in most cases, this seems confusing whenever you want to build for a specific commit of duckdb. Making everything explicit is the most clear and even though its ugly, its at least somewhat clear whats going on.
