### PR TITLE
Add optional `python3` dependency and move tests to v1.1.1

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -19,7 +19,7 @@ jobs:
       extension_name: quack
       override_repository: duckdb/extension-template
       override_ref: main
-      duckdb_version: v1.1.0
+      duckdb_version: v1.1.1
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp;go;python3'
@@ -34,6 +34,6 @@ jobs:
       override_ref: 94f887bd539ec0d5ed0d31bd01ff3845cf378a9d
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
-      duckdb_version: v1.1.0
+      duckdb_version: v1.1.1
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64'
       extra_toolchains: 'rust'

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -22,7 +22,7 @@ jobs:
       duckdb_version: v1.1.0
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
-      extra_toolchains: 'parser_tools;fortran;omp;go'
+      extra_toolchains: 'parser_tools;fortran;omp;go;python3'
       custom_toolchain_script: true
 
   delta-extension-main:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -71,7 +71,7 @@ on:
         type: string
         default: "duckdb/extension-ci-tools"
       # Pass extra toolchains
-      #   available: (rust, fortran, omp)
+      #   available: (parser_tools, rust, fortran, omp, python3)
       extra_toolchains:
         required: false
         type: string

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ DuckDB's [Extension Template](https://github.com/duckdb/extension-template/actio
 | Extension-ci-tools Branch | DuckDB target version | Actively maintained? |
 |---------------------------|-----------------------|----------------------|
 | main                      | main                  | yes                  |
-| v1.1.0                    | v1.1.0                | yes                  |
+| v1.1.1                    | v1.1.1                | yes                  |
+| v1.1.0                    | v1.1.0                | no                   |
 | v1.0.0                    | v1.0.0                | no                   |
 | v0.10.3                   | v0.10.3               | no                   |
 | v0.10.2                   | v0.10.2               | no                   |

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -90,3 +90,10 @@ RUN case "$extra_toolchains" in \
   ;; \
 esac
 ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Install Python3
+RUN case "$extra_toolchains" in \
+  *\;python3\;*) \
+    apt-get install -y -qq python3 \
+  ;; \
+esac

--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -71,3 +71,10 @@ RUN if [[ $extra_toolchains == *";go;"* ]]; then \
       tar -C /usr/local -xzf go1.23.1.linux-amd64.tar.gz; \
 fi
 ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Install Python3
+RUN case "$extra_toolchains" in \
+  *\;python3\;*) \
+    yum install -y python3; \
+  ;; \
+esac

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -89,3 +89,10 @@ RUN case "$extra_toolchains" in \
     apt-get install -y -qq golang-go \
   ;; \
 esac
+
+# Install Python3
+RUN case "$extra_toolchains" in \
+  *\;python3\;*) \
+    apt-get install -y -qq python3 \
+  ;; \
+esac


### PR DESCRIPTION
Python3 was not already installed in the Linux Docker containers jobs (while it's implicit in the OSX / Windows / Wasm runners).

This is a good test since it uses compilations paths with no python, that expecially on Linux might be relevant.
Still extension might want to rely on Python being there, for example [shellfs](https://community-extensions.duckdb.org/extensions/shellfs.html) used python for testing, and was now breaking.

This should address 1/3 of https://github.com/duckdb/community-extensions/issues/127
