### PR TITLE
Add skip_tests input, to avoid performing testing step

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -95,6 +95,11 @@ on:
         required: false
         type: string
         default: ""
+      # If set tot true, skip tests
+      skip_tests:
+        required: false
+        type: boolean
+        default: false
       # DEPRECATED: use extra_toolchains instead
       enable_rust:
         required: false
@@ -278,7 +283,7 @@ jobs:
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make release
 
       - name: Test extension
-        if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test
 
@@ -425,7 +430,7 @@ jobs:
           make release
 
       - name: Test Extension
-        if: ${{ matrix.osx_build_arch == 'x86_64'}}
+        if: ${{ matrix.osx_build_arch == 'x86_64' && inputs.skip_tests == false }}
         shell: bash
         run: |
           make test
@@ -561,6 +566,7 @@ jobs:
           bash scripts/setup-custom-toolchain.sh
 
       - name: Build & test extension
+        if: ${{ inputs.skip_tests == false }}
         env:
           DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
           DUCKDB_PLATFORM_RTOOLS: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' && 1 || 0 }}


### PR DESCRIPTION
Triggered by failures at https://github.com/duckdb/community-extensions/pull/128, that are independent from the extension but due to testing process implying rebuilding stuff.

This will provide an escape hatch for that extension (that can be rebuild skipping the tests), but that might be of minor but general utility to have. Especially since tests might be brittle or depend on ordering (say other extensions might be needed).