### PR TITLE
Fixup skipping of tests (skip release & test_release on Windows)

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -565,6 +565,14 @@ jobs:
         run: |
           bash scripts/setup-custom-toolchain.sh
 
+      - name: Build extension
+        if: ${{ inputs.skip_tests == true }}
+        env:
+          DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+          DUCKDB_PLATFORM_RTOOLS: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' && 1 || 0 }}
+        run: |
+          make release
+
       - name: Build & test extension
         if: ${{ inputs.skip_tests == false }}
         env:


### PR DESCRIPTION
This is needed otherwise passing `skip_tests` would have no extension built on Windows, see for example the CI run at: https://github.com/carlopi/community-extensions/actions/runs/11131357303