### PR TITLE
Move duckdb specifics from workflow to Makefile

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -139,8 +139,9 @@ jobs:
           repository: ${{ inputs.override_ci_tools_repository }}
 
       - name: Checkout DuckDB to version
+        if: ${{inputs.duckdb_version != ''}}
         run: |
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_tag }} make set_duckdb_version
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -229,8 +230,9 @@ jobs:
           repository: ${{ inputs.override_ci_tools_repository }}
 
       - name: Checkout DuckDB to version
+        if: ${{inputs.duckdb_version != ''}}
         run: |
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_tag }} make set_duckdb_version
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -368,8 +370,9 @@ jobs:
           repository: ${{ inputs.override_ci_tools_repository }}
 
       - name: Checkout DuckDB to version
+        if: ${{inputs.duckdb_version != ''}}
         run: |
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_tag }} make set_duckdb_version
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -538,8 +541,9 @@ jobs:
           repository: ${{ inputs.override_ci_tools_repository }}
 
       - name: Checkout DuckDB to version
+        if: ${{inputs.duckdb_version != ''}}
         run: |
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_tag }} make set_duckdb_version
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -639,8 +643,9 @@ jobs:
           repository: ${{ inputs.override_ci_tools_repository }}
 
       - name: Checkout DuckDB to version
+        if: ${{inputs.duckdb_version != ''}}
         run: |
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_tag }} make set_duckdb_version
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -152,32 +152,34 @@ jobs:
 
       - id: parse-matrices
         run: |
-          python3 ${{ inputs.matrix_parse_script }} --input ./duckdb/.github/config/distribution_matrix.json --select_os linux --output linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
-          python3 ${{ inputs.matrix_parse_script }} --input ./duckdb/.github/config/distribution_matrix.json --select_os osx --output osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
-          python3 ${{ inputs.matrix_parse_script }} --input ./duckdb/.github/config/distribution_matrix.json --select_os windows --output windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
-          python3 ${{ inputs.matrix_parse_script }} --input ./duckdb/.github/config/distribution_matrix.json --select_os wasm --output wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
+          mkdir build
+          make output_distribution_matrix > build/distribution_matrix.json
+          python3 ${{ inputs.matrix_parse_script }} --input build/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
+          python3 ${{ inputs.matrix_parse_script }} --input build/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
+          python3 ${{ inputs.matrix_parse_script }} --input build/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
+          python3 ${{ inputs.matrix_parse_script }} --input build/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
 
       - id: set-matrix-linux
         run: |
-          linux_matrix="`cat linux_matrix.json`"
+          linux_matrix="`cat build/linux_matrix.json`"
           echo linux_matrix=$linux_matrix >> $GITHUB_OUTPUT
           echo `cat $GITHUB_OUTPUT`
 
       - id: set-matrix-osx
         run: |
-          osx_matrix="`cat osx_matrix.json`"
+          osx_matrix="`cat build/osx_matrix.json`"
           echo osx_matrix=$osx_matrix >> $GITHUB_OUTPUT
           echo `cat $GITHUB_OUTPUT`
 
       - id: set-matrix-windows
         run: |
-          windows_matrix="`cat windows_matrix.json`"
+          windows_matrix="`cat build/windows_matrix.json`"
           echo windows_matrix=$windows_matrix >> $GITHUB_OUTPUT
           echo `cat $GITHUB_OUTPUT`
 
       - id: set-matrix-wasm
         run: |
-          wasm_matrix="`cat wasm_matrix.json`"
+          wasm_matrix="`cat build/wasm_matrix.json`"
           echo wasm_matrix=$wasm_matrix >> $GITHUB_OUTPUT
           echo `cat $GITHUB_OUTPUT`
 

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -222,6 +222,14 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
+        with:
+          path: 'extension-ci-tools'
+          ref: ${{ inputs.ci_tools_version }}
+          repository: ${{ inputs.override_ci_tools_repository }}
+          fetch-depth: 0
+
       - name: Checkout DuckDB to version
         run: |
           DUCKDB_GIT_VERSION=${{ inputs.duckdb_tag }} make set_duckdb_version

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -131,6 +131,14 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
+        with:
+          path: 'extension-ci-tools'
+          ref: ${{ inputs.ci_tools_version }}
+          repository: ${{ inputs.override_ci_tools_repository }}
+          fetch-depth: 0
+
       - name: Checkout DuckDB to version
         run: |
           DUCKDB_GIT_VERSION=${{ inputs.duckdb_tag }} make set_duckdb_version
@@ -153,7 +161,7 @@ jobs:
       - id: parse-matrices
         run: |
           mkdir build
-          make output_distribution_matrix > build/distribution_matrix.json
+          make output_distribution_matrix | tail -n +2 > build/distribution_matrix.json
           python3 ${{ inputs.matrix_parse_script }} --input build/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
           python3 ${{ inputs.matrix_parse_script }} --input build/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
           python3 ${{ inputs.matrix_parse_script }} --input build/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -542,8 +542,10 @@ jobs:
 
       - name: Checkout DuckDB to version
         if: ${{inputs.duckdb_version != ''}}
+        env:
+          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
         run: |
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
+          make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -552,8 +554,10 @@ jobs:
 
       - name: Tag DuckDB extension
         if: ${{inputs.duckdb_tag != ''}}
+        env:
+          DUCKDB_TAG: ${{ inputs.duckdb_tag }}
         run: |
-          DUCKDB_TAG=${{ inputs.duckdb_tag }} make set_duckdb_tag
+          make set_duckdb_tag
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -133,8 +133,7 @@ jobs:
 
       - name: Checkout DuckDB to version
         run: |
-          cd duckdb
-          git checkout ${{ inputs.duckdb_version }}
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_tag }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -149,8 +148,7 @@ jobs:
       - name: Tag DuckDB extension
         if: ${{inputs.duckdb_tag != ''}}
         run: |
-          cd duckdb
-          git tag ${{ inputs.duckdb_tag }}
+          DUCKDB_TAG=${{ inputs.duckdb_tag }} make set_duckdb_tag
 
       - id: parse-matrices
         run: |
@@ -216,8 +214,7 @@ jobs:
 
       - name: Checkout DuckDB to version
         run: |
-          cd duckdb
-          git checkout ${{ inputs.duckdb_version }}
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_tag }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -227,8 +224,7 @@ jobs:
       - name: Tag DuckDB extension
         if: ${{inputs.duckdb_tag != ''}}
         run: |
-          cd duckdb
-          git tag ${{ inputs.duckdb_tag }}
+          DUCKDB_TAG=${{ inputs.duckdb_tag }} make set_duckdb_tag
 
       - uses: actions/checkout@v4
         name: Checkout Extension CI tools
@@ -358,8 +354,7 @@ jobs:
 
       - name: Checkout DuckDB to version
         run: |
-          cd duckdb
-          git checkout ${{ inputs.duckdb_version }}
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_tag }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -369,9 +364,7 @@ jobs:
       - name: Tag DuckDB extension
         if: ${{inputs.duckdb_tag != ''}}
         run: |
-          cd duckdb
-          git tag ${{ inputs.duckdb_tag }}
-
+          DUCKDB_TAG=${{ inputs.duckdb_tag }} make set_duckdb_tag
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11.1
@@ -532,8 +525,7 @@ jobs:
 
       - name: Checkout DuckDB to version
         run: |
-          cd duckdb
-          git checkout ${{ inputs.duckdb_version }}
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_tag }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -543,9 +535,7 @@ jobs:
       - name: Tag DuckDB extension
         if: ${{inputs.duckdb_tag != ''}}
         run: |
-          cd duckdb
-          git tag ${{ inputs.duckdb_tag }}
-
+          DUCKDB_TAG=${{ inputs.duckdb_tag }} make set_duckdb_tag
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
@@ -637,8 +627,7 @@ jobs:
 
       - name: Checkout DuckDB to version
         run: |
-          cd duckdb
-          git checkout ${{ inputs.duckdb_version }}
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_tag }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -648,8 +637,7 @@ jobs:
       - name: Tag DuckDB extension
         if: ${{inputs.duckdb_tag != ''}}
         run: |
-          cd duckdb
-          git tag ${{ inputs.duckdb_tag }}
+          DUCKDB_TAG=${{ inputs.duckdb_tag }} make set_duckdb_tag
 
       - uses: mymindstorm/setup-emsdk@v13
         with:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -137,7 +137,6 @@ jobs:
           path: 'extension-ci-tools'
           ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
-          fetch-depth: 0
 
       - name: Checkout DuckDB to version
         run: |
@@ -228,7 +227,6 @@ jobs:
           path: 'extension-ci-tools'
           ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
-          fetch-depth: 0
 
       - name: Checkout DuckDB to version
         run: |
@@ -368,7 +366,6 @@ jobs:
           path: 'extension-ci-tools'
           ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
-          fetch-depth: 0
 
       - name: Checkout DuckDB to version
         run: |
@@ -539,7 +536,6 @@ jobs:
           path: 'extension-ci-tools'
           ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
-          fetch-depth: 0
 
       - name: Checkout DuckDB to version
         run: |
@@ -641,7 +637,6 @@ jobs:
           path: 'extension-ci-tools'
           ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
-          fetch-depth: 0
 
       - name: Checkout DuckDB to version
         run: |

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -137,3 +137,6 @@ set_duckdb_version:
 set_duckdb_tag:
 	cd duckdb
 	git tag $(DUCKDB_TAG)
+
+output_distribution_matrix:
+	cat ./duckdb/.github/config/distribution_matrix.json

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -139,4 +139,4 @@ set_duckdb_tag:
 	git tag $(DUCKDB_TAG)
 
 output_distribution_matrix:
-	cat ./duckdb/.github/config/distribution_matrix.json
+	cat duckdb/.github/config/distribution_matrix.json

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -129,3 +129,11 @@ clean:
 
 clean-python:
 	make $@ -C $(DUCKDB_SRCDIR)
+
+set_duckdb_version:
+	cd duckdb
+	git checkout $(DUCKDB_GIT_VERSION)
+
+set_duckdb_tag:
+	cd duckdb
+	git tag $(DUCKDB_TAG)

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -131,12 +131,10 @@ clean-python:
 	make $@ -C $(DUCKDB_SRCDIR)
 
 set_duckdb_version:
-	cd duckdb
-	git checkout $(DUCKDB_GIT_VERSION)
+	cd duckdb && git checkout $(DUCKDB_GIT_VERSION)
 
 set_duckdb_tag:
-	cd duckdb
-	git tag $(DUCKDB_TAG)
+	cd duckdb && git tag $(DUCKDB_TAG)
 
 output_distribution_matrix:
 	cat duckdb/.github/config/distribution_matrix.json


### PR DESCRIPTION
Idea is make room for other kind of extensions that might not have such a strict dependency / need for the duckdb submodule.

This is mostly connected to C-API extensions, but possibly also other ways of handling dependencies or other use cases can also become relevant.

Currently there are no changes that actually would allow a C-API extension, but I think overriding `set_duckdb_version`, `set_duckdb_tag` and `output_distribution_matrix` to no-op, no-op and returning a default might work fine.