### PR TITLE
Free Up Storage Space to Support Complex Builds

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -198,6 +198,10 @@ jobs:
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
 
     steps:
+      - name: Free up some unused space
+        run: |
+          docker rmi $(docker images -a -q)
+
       - uses: actions/checkout@v4
         name: Checkout override repository
         if: ${{inputs.override_repository != ''}}


### PR DESCRIPTION
This Pull Request introduces a small change aimed at freeing up storage space to accommodate more complex builds, such as the BigQuery extension. The idea, its benefits, and the problem it addresses are detailed in [Issue #127](https://github.com/duckdb/community-extensions/issues/127).

The proposed changes add an extra step in the build process that removes cached docker images that are not used. 