### PR TITLE
Add signature as a valid Wasm custom segment

### DIFF
--- a/scripts/append_extension_metadata.py
+++ b/scripts/append_extension_metadata.py
@@ -1,6 +1,25 @@
 import argparse
 import shutil
 
+def start_signature():
+    // This is needed so that Wasm binaries are valid
+    encoded_string = ''.encode('ascii')
+    // 0 for custom section
+    encoded_string += int(0).to_bytes(1)
+    // 213 in hex = 531 in decimal, total lenght of what follows (1 + 16 + 2 + 8x32 + 256)
+    // [1(continuation) + 0010011(payload) = \x93 -> 147, 0(continuation) + 10(payload) = \x04 -> 4]
+    encoded_string += int(147).to_bytes(1)
+    encoded_string += int(4).to_bytes(1)
+    // 10 in hex = 16 in decimal, lenght of name, 1 byte
+    encoded_string += int(16).to_bytes(1)
+    // the name of the WebAssembly custom section, 16 bytes
+    encoded_string += b'duckdb_signature'
+    // 1000 in hex, 512 in decimal
+    // [1(continuation) + 0000000(payload) = -> 128, 0(continuation) + 100(payload) -> 4],
+    encoded_string += int(128).to_bytes(1)
+    encoded_string += int(4).to_bytes(1)
+    return encoded_string
+
 def padded_byte_string(input):
     encoded_string = input.encode('ascii')
     encoded_string += b'\x00' * (32 - len(encoded_string))
@@ -35,6 +54,7 @@ def main():
     # Then append the metadata to the tmp file
     print(f" - Metadata:")
     with open(OUTPUT_FILE_TMP, 'ab') as file:
+        file.write(start_signature())
         print(f"   - FIELD8 (unused)            = EMPTY")
         file.write(padded_byte_string(""))
         print(f"   - FIELD7 (unused)            = EMPTY")


### PR DESCRIPTION
This is needed for the Wasm target, otherwise the binary file is invalid. For other targets the extra few bytes are unnecessary, but for uniformity I think it's better to always have them (and this align to the behaviour of `duckdb/duckdb/script/append_metadata.cmake`)

Also port the cryptic comments from the original `append_metadata.cmake` script.