### PR TITLE
Cover Python's 'This environment is externally managed' error

### DIFF
--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -107,9 +107,10 @@ jobs:
           BUCKET_NAME: ${{ secrets.S3_DUCKDB_ORG_BUCKET }}
           DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.S3_DUCKDB_ORG_EXTENSION_SIGNING_PK }}
           DUCKDB_DEPLOY_SCRIPT_MODE: for_real
+          PIP_BREAK_SYSTEM_PACKAGES: 1
         run: |
           pwd
-          python3 -m pip install pip awscli
+          python3 -m pip install awscli
           git config --global --add safe.directory '*'
           cd duckdb
           git fetch --tags

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -208,7 +208,14 @@ jobs:
     steps:
       - name: Free up some unused space
         run: |
-          docker rmi $(docker images -a -q)
+          docker images -a -q > package.list
+          if [ -s package.list ]; then
+              echo "To be deleted"
+              cat package.list
+              echo "---"
+              docker rmi $(cat package.list)
+          fi
+          rm package.list
 
       - uses: actions/checkout@v4
         name: Checkout override repository


### PR DESCRIPTION
I think depending on the repository Python requirment (possibly due to bumping version) have changed, and now naked (= non virtual environment) `pip install` or `python3 -m pip install` throw the following erorr:

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

Workaround is passing this env variable.
Proper fix is out of scope now.