### PR TITLE
switch which macos arch runs the tests

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -453,7 +453,7 @@ jobs:
           make release
 
       - name: Test Extension
-        if: ${{ matrix.osx_build_arch == 'x86_64' && inputs.skip_tests == false }}
+        if: ${{ matrix.osx_build_arch == 'arm64' && inputs.skip_tests == false }}
         shell: bash
         run: |
           make test


### PR DESCRIPTION
We are running on arm runners now, right?