### PR TITLE
Prepare ci tools for extensions without DuckDB submodule

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -23,7 +23,6 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp;go;python3'
-      custom_toolchain_script: true
 
   delta-extension-main:
     name: Rust builds (using Delta extension)

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -311,14 +311,14 @@ jobs:
       - name: Test extension (inside docker)
         if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
         env:
-          LINUX_TESTS_IN_DOCKER=1
+          LINUX_TESTS_IN_DOCKER: 1
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test_release
 
       - name: Test extension (outside docker)
         if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
         env:
-          LINUX_TESTS_OUTSIDE_DOCKER=1
+          LINUX_TESTS_OUTSIDE_DOCKER: 1
         run: |
           make test_release
 

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -305,6 +305,7 @@ jobs:
         shell: bash
         env:
           DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
+          LINUX_CI_IN_DOCKER: 0
         run: |
           make configure_ci
 
@@ -326,6 +327,7 @@ jobs:
         if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
         env:
           DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
+          LINUX_CI_IN_DOCKER: 0
         run: |
           make test_release
 

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -465,7 +465,7 @@ jobs:
         if: ${{ matrix.osx_build_arch == 'arm64' && inputs.skip_tests == false }}
         shell: bash
         run: |
-          make test
+          make test_release
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -279,6 +279,7 @@ jobs:
           echo "OPENSSL_USE_STATIC_LIBS=true" >> docker_env.txt
           echo "DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}" >> docker_env.txt
           echo "DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }}" >> docker_env.txt
+          echo "LINUX_CI_IN_DOCKER=1" >> docker_env.txt
           echo "TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}" >> docker_env.txt
 
       - name: Generate timestamp for Ccache entry
@@ -300,26 +301,31 @@ jobs:
           restore-keys: |
             ccache-extension-distribution-${{ matrix.duckdb_arch }}-
 
-      - name: Run configure CI
+      - name: Run configure (outside Docker)
+        shell: bash
+        env:
+          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
+        run: |
+          make configure_ci
+
+      - name: Run configure (inside Docker)
         shell: bash
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make configure_ci
 
-      - name: Build extension
+      - name: Build extension (inside Docker)
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make release
 
       - name: Test extension (inside docker)
         if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
-        env:
-          LINUX_TESTS_IN_DOCKER: 1
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test_release
 
       - name: Test extension (outside docker)
         if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
         env:
-          LINUX_TESTS_OUTSIDE_DOCKER: 1
+          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
         run: |
           make test_release
 
@@ -449,7 +455,7 @@ jobs:
           echo "CPPFLAGS=-I/opt/homebrew/opt/libomp/include" >> $GITHUB_ENV
           echo "CXXFLAGS=-I/opt/homebrew/opt/libomp/include" >> $GITHUB_ENV
 
-      - name: Run configure CI
+      - name: Run configure
         shell: bash
         env:
           DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
@@ -592,7 +598,7 @@ jobs:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
           vcpkgGitURL: ${{ inputs.vcpkg_url }}
 
-      - name: Run configure CI
+      - name: Run configure
         shell: bash
         env:
           DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
@@ -712,7 +718,7 @@ jobs:
         with:
           key: ${{ github.job }}-${{ matrix.duckdb_arch }}
 
-      - name: Run configure CI
+      - name: Run configure
         shell: bash
         env:
           DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -308,10 +308,19 @@ jobs:
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make release
 
-      - name: Test extension
+      - name: Test extension (inside docker)
         if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
+        env:
+          LINUX_TESTS_IN_DOCKER=1
         run: |
-          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test_release
+
+      - name: Test extension (outside docker)
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
+        env:
+          LINUX_TESTS_OUTSIDE_DOCKER=1
+        run: |
+          make test_release
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -76,11 +76,6 @@ on:
         required: false
         type: string
         default: ""
-      # If set, the setup will look for a script in `./scripts/custom-toolchain-script.sh` to run
-      custom_toolchain_script:
-        required: false
-        type: boolean
-        default: false
       rust_logs:
         required: false
         type: boolean
@@ -283,6 +278,7 @@ jobs:
           echo "OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> docker_env.txt
           echo "OPENSSL_USE_STATIC_LIBS=true" >> docker_env.txt
           echo "DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}" >> docker_env.txt
+          echo "DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }}" >> docker_env.txt
           echo "TOOLCHAIN_FLAGS=${{ matrix.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}" >> docker_env.txt
 
       - name: Generate timestamp for Ccache entry
@@ -303,6 +299,11 @@ jobs:
           key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ steps.ccache_timestamp.outputs.timestamp }}
           restore-keys: |
             ccache-extension-distribution-${{ matrix.duckdb_arch }}-
+
+      - name: Run configure CI
+        shell: bash
+        run: |
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make configure_ci
 
       - name: Build extension
         run: |
@@ -448,16 +449,15 @@ jobs:
           echo "CPPFLAGS=-I/opt/homebrew/opt/libomp/include" >> $GITHUB_ENV
           echo "CXXFLAGS=-I/opt/homebrew/opt/libomp/include" >> $GITHUB_ENV
 
-      - name: Run custom toolchain script
-        if: ${{ inputs.custom_toolchain_script }}
+      - name: Run configure CI
         shell: bash
+        env:
+          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
         run: |
-          bash scripts/setup-custom-toolchain.sh
+          make configure_ci
 
       - name: Build extension
         shell: bash
-        env:
-          DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
         run: |
           make release
 
@@ -592,21 +592,23 @@ jobs:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
           vcpkgGitURL: ${{ inputs.vcpkg_url }}
 
-      - name: Run custom toolchain script
-        if: ${{ inputs.custom_toolchain_script }}
+      - name: Run configure CI
         shell: bash
+        env:
+          DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+          DUCKDB_PLATFORM_RTOOLS: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' && 1 || 0 }}
+          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
         run: |
-          bash scripts/setup-custom-toolchain.sh
+          make configure_ci
 
       - name: Build extension
-        if: ${{ inputs.skip_tests == true }}
         env:
           DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
           DUCKDB_PLATFORM_RTOOLS: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' && 1 || 0 }}
         run: |
           make release
 
-      - name: Build & test extension
+      - name: Test extension
         if: ${{ inputs.skip_tests == false }}
         env:
           DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
@@ -710,11 +712,12 @@ jobs:
         with:
           key: ${{ github.job }}-${{ matrix.duckdb_arch }}
 
-      - name: Run custom toolchain script
-        if: ${{ inputs.custom_toolchain_script }}
+      - name: Run configure CI
         shell: bash
+        env:
+          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
         run: |
-          bash scripts/setup-custom-toolchain.sh
+          make configure_ci
 
       - name: Build Wasm module
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -49,7 +49,7 @@ on:
       matrix_parse_script:
         required: false
         type: string
-        default: "./duckdb/scripts/modify_distribution_matrix.py"
+        default: "./extension-ci-tools/scripts/modify_distribution_matrix.py"
       # Enable building the DuckDB Shell
       build_duckdb_shell:
         required: false

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -84,8 +84,8 @@ TEST_DEBUG_TARGET=test_debug_internal
 TEST_RELDEBUG_TARGET=test_reldebug_internal
 
 # Disable testing outside docker: the unittester is currently dynamically linked by default
-ifeq($(LINUX_TESTS_OUTSIDE_DOCKER),1)
-    SKIP_TESTS=1
+ifeq ($(LINUX_TESTS_OUTSIDE_DOCKER),1)
+	SKIP_TESTS=1
 endif
 
 ifeq ($(SKIP_TESTS),1)

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -159,3 +159,6 @@ set_duckdb_tag:
 
 output_distribution_matrix:
 	cat duckdb/.github/config/distribution_matrix.json
+
+configure_ci:
+	@echo "configure_ci is a NOP"

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -6,8 +6,9 @@
 #   EXT_FLAGS         : Extra CMake flags to pass to the build
 #   EXT_RELEASE_FLAGS : Extra CMake flags to pass to the release build
 #   EXT_DEBUG_FLAGS   : Extra CMake flags to pass to the debug build
+#   SKIP_TESTS        : Replaces all test targets with a NOP step
 
-.PHONY: all clean format debug release pull update wasm_mvp wasm_eh wasm_threads
+.PHONY: all clean clean-python format debug release pull update wasm_mvp wasm_eh wasm_threads test test_release test_debug test_reldebug test_release_internal test_debug_internal test_reldebug_internal set_duckdb_version set_duckdb_tag  output_distribution_matrix
 
 all: release
 
@@ -78,14 +79,29 @@ reldebug:
 # Main tests
 test: test_release
 
-test_release:
+TEST_RELEASE_TARGET=test_release_internal
+TEST_DEBUG_TARGET=test_debug_internal
+TEST_RELDEBUG_TARGET=test_reldebug_internal
+
+ifeq ($(SKIP_TESTS),1)
+	TEST_RELEASE_TARGET=tests_skipped
+	TEST_DEBUG_TARGET=tests_skipped
+	TEST_RELDEBUG_TARGET=tests_skipped
+endif
+
+test_release: $(TEST_RELEASE_TARGET)
+test_debug: $(TEST_DEBUG_TARGET)
+test_reldebug: $(TEST_RELDEBUG_TARGET)
+
+test_release_internal:
 	./build/release/$(TEST_PATH) "$(PROJ_DIR)test/*"
-
-test_debug:
+test_debug_internal:
 	./build/debug/$(TEST_PATH) "$(PROJ_DIR)test/*"
-
-test_reldebug:
+test_reldebug_internal:
 	./build/reldebug/$(TEST_PATH) "$(PROJ_DIR)test/*"
+
+tests_skipped:
+	@echo "Skipping tests..."
 
 # WASM config
 VCPKG_EMSDK_FLAGS=-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$(EMSDK)/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -78,13 +78,13 @@ reldebug:
 # Main tests
 test: test_release
 
-test_release: release
+test_release:
 	./build/release/$(TEST_PATH) "$(PROJ_DIR)test/*"
 
-test_debug: debug
+test_debug:
 	./build/debug/$(TEST_PATH) "$(PROJ_DIR)test/*"
 
-test_reldebug: reldebug
+test_reldebug:
 	./build/reldebug/$(TEST_PATH) "$(PROJ_DIR)test/*"
 
 # WASM config

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -106,7 +106,7 @@ test_reldebug_internal:
 	./build/reldebug/$(TEST_PATH) "$(PROJ_DIR)test/*"
 
 tests_skipped:
-	@echo "Skipping tests..."
+	@echo "Tests are skipped in this run..."
 
 # WASM config
 VCPKG_EMSDK_FLAGS=-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$(EMSDK)/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake
@@ -161,4 +161,4 @@ output_distribution_matrix:
 	cat duckdb/.github/config/distribution_matrix.json
 
 configure_ci:
-	@echo "configure_ci is a NOP"
+	@echo "configure_ci step is skipped for this extension build..."

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -84,7 +84,7 @@ TEST_DEBUG_TARGET=test_debug_internal
 TEST_RELDEBUG_TARGET=test_reldebug_internal
 
 # Disable testing outside docker: the unittester is currently dynamically linked by default
-ifeq ($(LINUX_TESTS_OUTSIDE_DOCKER),1)
+ifeq ($(LINUX_CI_IN_DOCKER),0)
 	SKIP_TESTS=1
 endif
 

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -83,6 +83,11 @@ TEST_RELEASE_TARGET=test_release_internal
 TEST_DEBUG_TARGET=test_debug_internal
 TEST_RELDEBUG_TARGET=test_reldebug_internal
 
+# Disable testing outside docker: the unittester is currently dynamically linked by default
+ifeq($(LINUX_TESTS_OUTSIDE_DOCKER),1)
+    SKIP_TESTS=1
+endif
+
 ifeq ($(SKIP_TESTS),1)
 	TEST_RELEASE_TARGET=tests_skipped
 	TEST_DEBUG_TARGET=tests_skipped

--- a/scripts/append_extension_metadata.py
+++ b/scripts/append_extension_metadata.py
@@ -62,10 +62,11 @@ def main():
         try:
             with open(args.duckdb_platform_file, 'r') as file:
                 PLATFORM = file.read().strip()
-                if not PLATFORM:
-                    raise Exception("File is empty!")
         except Exception as e:
-            raise Exception(f"Failed to read platform from file: {args.duckdb_platform_file}: {e}")
+            print(f"Failed to read platform from file {args.duckdb_platform_file}")
+            raise
+        if not PLATFORM:
+            raise Exception(f"Platform file passed to script is empty: {args.duckdb_platform_file}")
     else:
         raise Exception(f"Neither --duckdb-platform nor --duckdb-platform-file found, please specify the platform using either")
 


### PR DESCRIPTION
After this PR, my experimental rust-based extension template (https://github.com/samansmink/extension-template-rs) should be one step closer to reality.

This requires some tweaks to the workflows because things like running tests and platform detection are different from the C++ api based extensions that do have a duckdb submodule in their repository.

Changes:
- you can now disable running the tests by setting the SKIP_TESTS variable
- tests on linux are now run twice: once inside docker, once outside
- there's a new `configure_ci` step which is called once inside docker, once outside
- extensions can detect which one is being called and set SKIP_TESTS for either to work around any issues
- `test_*` targets no longer automatically build too, this avoids double building that would happen
- `custom-toolchain-script.sh` was removed again in favor of more flexible `make configure_ci`
