### PR TITLE
Add `linux_amd64_musl` platform

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -35,6 +35,7 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3'
+      exclude_archs: 'linux_amd64_musl'
 
   extension-template-rust:
     name: Extension template (Rust)
@@ -47,7 +48,7 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'rust;python3'
-      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw' # TODO: remove once fixed upstream
+      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl' # TODO: remove once fixed upstream
 
   delta-extension-main:
     name: Rust builds (using Delta extension)
@@ -59,5 +60,5 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       duckdb_version: v1.1.3
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;linux_amd64_musl'
       extra_toolchains: 'rust'

--- a/config/distribution_matrix.json
+++ b/config/distribution_matrix.json
@@ -15,6 +15,11 @@
         "duckdb_arch": "linux_arm64",
         "container": "ubuntu:18.04",
         "vcpkg_triplet": "arm64-linux"
+      },
+      {
+        "duckdb_arch": "linux_amd64_musl",
+        "container": "alpine:3",
+        "vcpkg_triplet": "x64-linux"
       }
     ]
   },

--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -1,0 +1,84 @@
+FROM alpine:3
+
+###
+# Base image setup
+###
+
+# Setup the basic necessities
+RUN apk update --y -qq
+RUN apk add -qq ccache cmake git ninja ninja-build clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers
+
+# Setup VCPKG n a mounted volume TODO: figure out how to cache this
+ARG vcpkg_url
+ARG vcpkg_commit
+RUN mkdir /vcpkg && \
+    cd /vcpkg && \
+    git init && \
+    git remote add origin $vcpkg_url && \
+    git fetch origin $vcpkg_commit && \
+    git checkout $vcpkg_commit && \
+    VCPKG_FORCE_SYSTEM_BINARIES=1 ./bootstrap-vcpkg.sh
+ENV VCPKG_ROOT=/vcpkg
+ENV VCPKG_TOOLCHAIN_PATH=/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+# Common environment variables
+ENV GEN=ninja
+ENV DUCKDB_PLATFORM=linux_amd64_musl
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
+
+# Specify where we expect the extension to be mounted and use that as working dir
+VOLUME /duckdb_build_dir
+WORKDIR /duckdb_build_dir
+
+# Mount for ccache to allow restoring ccache in GH actions
+VOLUME /ccache_dir
+ENV CCACHE_DIR=/ccache_dir
+ENV CCACHE_COMPRESS=TRUE
+ENV CCACHE_COMPRESSLEVEL=6
+ENV CCACHE_MAXSIZE=400M
+
+###
+# Conditionally configure some extra dependencies
+###
+# a `;` separated list of extra toolchains to install (passed in like this to makes things easier through GitHub Actions)
+# Note that it should start and end with a `;` e.g. `;rust;parser_tools;`
+ARG extra_toolchains
+
+# NOTE: the weird case conditionals are because of bash limitations in the ubuntu image used (see https://stackoverflow.com/questions/229551/how-to-check-if-a-string-contains-a-substring-in-bash)
+
+# Install Parser tools
+RUN case "$extra_toolchains" in \
+  *\;parser_tools\;*) \
+    apk add -qq bison flex \
+  ;; \
+esac
+
+# Install Fortran
+RUN case "$extra_toolchains" in \
+  *\;fortran\;*) \
+    apk add -qq gfortran \
+  ;; \
+esac
+
+# Configure Rust
+RUN case "$extra_toolchains" in \
+  *\;rust\;*) \
+    curl https://sh.rustup.rs -sSf | bash -s -- -y \
+  ;; \
+esac
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Configure go
+RUN case "$extra_toolchains" in \
+  *\;go\;*) \
+    apk add -qq go \
+  ;; \
+esac
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Install Python3
+RUN case "$extra_toolchains" in \
+  *\;python3\;*) \
+    apk add -qq python3 \
+  ;; \
+esac


### PR DESCRIPTION
This has been tested to work for all extensions in out_of_tree_extensions.cmake but for `arrow` and `mysql_scanner`.

Connected to https://github.com/duckdb/duckdb/pull/15429, introducing the 2 musl targets, this implements building musl extensions for one of the `amd64` version.

Once this PR is in, the duckdb/duckdb PR can be updated to build extensions using the dockerfile added here, but they can go in independently.

This is currently removed from capi, rust capi, and delta, since all of them fail for different reasons to be investigated on a side.
capi -> duckdb builds with wrong platform backed in, so they are incompatible (can be lifted after https://github.com/duckdb/duckdb/pull/15429 is merged)
rust capi -> there is an error in linking to produce a dynamic library, possibly rust toolchain needs to be set up better
delta -> currently delta-kernel is not compatible
They can be reviewed looking at the failures here: https://github.com/carlopi/extension-ci-tools/actions/runs/12448574445