### PR TITLE
Bump vcpkg commit, to re-align to duckdb/duckdb

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -44,7 +44,7 @@ on:
       vcpkg_commit:
         required: false
         type: string
-        default: "a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6"
+        default: "5e5d0e1cd7785623065e77eff011afdeec1a3574"
       # Override the default script producing the matrices. Allows specifying custom matrices.
       matrix_parse_script:
         required: false


### PR DESCRIPTION
Given duckdb/duckdb builds since a couple of weeks with that commit it should be fine.

A given extension can always pin the vcpkg commit to a lower version if needed.