### PR TITLE
Initial version of alpine docker

### DIFF
--- a/docker/linux_amd64/alpine/Dockerfile
+++ b/docker/linux_amd64/alpine/Dockerfile
@@ -1,0 +1,55 @@
+FROM alpine:3.20
+
+ARG DUCKDB_VER=v1.1.3
+ARG vcpkg_url="https://github.com/microsoft/vcpkg.git"
+ARG vcpkg_commit="a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6"
+
+# Install build dependencies
+RUN apk update && \
+    apk add --no-cache \
+      build-base \
+      ccache \
+      cmake \
+      curl \
+      git \
+      g++ \ 
+      make \
+      ninja \
+      pkgconfig \
+      python3 \
+      rustup \
+      tar \
+      unzip \
+      zip 
+
+# Setup VCPKG n a mounted volume TODO: figure out how to cache this
+RUN mkdir /vcpkg && \
+    cd /vcpkg && \
+    git init && \
+    git remote add origin $vcpkg_url && \
+    git fetch origin $vcpkg_commit && \
+    git checkout $vcpkg_commit && \
+    ./bootstrap-vcpkg.sh
+ENV VCPKG_ROOT=/vcpkg
+ENV VCPKG_TOOLCHAIN_PATH=/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+# Common environment variables
+ENV GEN=ninja
+
+# Specify where we expect the extension to be mounted and use that as working dir
+VOLUME /duckdb_build_dir
+WORKDIR /duckdb_build_dir
+
+# Mount for ccache to allow restoring ccache in GH actions
+VOLUME /ccache_dir
+ENV CCACHE_DIR=/ccache_dir
+ENV CCACHE_COMPRESS=TRUE
+ENV CCACHE_COMPRESSLEVEL=6
+ENV CCACHE_MAXSIZE=400M
+
+# extension-ci needs rust?
+
+# Install the Rust toolchain
+RUN rustup-init -y --default-toolchain stable
+
+RUN git clone --branch $DUCKDB_VER https://github.com/duckdb/extension-ci-tools

--- a/docker/linux_amd64/alpine/env.txt
+++ b/docker/linux_amd64/alpine/env.txt
@@ -1,0 +1,8 @@
+VCPKG_TARGET_TRIPLET=x64-linux 
+BUILD_SHELL=0
+OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/x64-linux
+OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/x64-linux
+OPENSSL_USE_STATIC_LIBS=true
+DUCKDB_PLATFORM=linux-x64
+DUCKDB_GIT_VERSION=1.1.3
+LINUX_CI_IN_DOCKER=1


### PR DESCRIPTION
This docker attempts to create an environment where an extension author can simply mount their extension within a pre-built image and get it to build.

This image doesn't quite do that yet. But hopefully a starting point for further discussion and feedback.

More [context](https://github.com/duckdb/extension-template/issues/100)

Usage:

```
docker buildx build -t duckdb_ext_tools:latest . --load -f docker/Dockerfile
docker run -v $(pwd):/duckdb_build_dir/my_extension --env-file=docker/env.txt -it  duckdb_ext_tools:latest
```