### PR TITLE
Allows either `_rtools`OR `_mingw` in _extension_distribution (but only mingw in the json)

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -48,7 +48,7 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'rust;python3'
-      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl' # TODO: remove once fixed upstream
+      exclude_archs: 'windows_amd64_mingw;linux_amd64_musl' # TODO: remove once fixed upstream
 
   delta-extension-main:
     name: Rust builds (using Delta extension)
@@ -60,5 +60,5 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       duckdb_version: v1.1.3
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64;linux_amd64_musl'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_amd64_musl'
       extra_toolchains: 'rust'

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -467,8 +467,8 @@ jobs:
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
       BUILD_SHELL: ${{ inputs.build_duckdb_shell && '1' || '0' }}
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-      CC: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' && 'gcc' || '' }}
-      CXX: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' && 'g++' || '' }}
+      CC: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 'gcc' || '' }}
+      CXX: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 'g++' || '' }}
 
     steps:
       - name: Keep \n line endings
@@ -513,14 +513,14 @@ jobs:
           choco install winflexbison3
 
       - uses: r-lib/actions/setup-r@v2
-        if: matrix.duckdb_arch == 'windows_amd64_rtools'
+        if:  matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw'
         with:
           r-version: 'devel'
           update-rtools: true
           rtools-version: '42' # linker bug in 43
 
       - name: setup rtools gcc for vcpkg
-        if: matrix.duckdb_arch == 'windows_amd64_rtools'
+        if:  matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw'
         run: |
           cp C:/rtools42/x86_64-w64-mingw32.static.posix/bin/gcc.exe C:/rtools42/x86_64-w64-mingw32.static.posix/bin/x86_64-w64-mingw32-gcc.exe 
           cp C:/rtools42/x86_64-w64-mingw32.static.posix/bin/g++.exe C:/rtools42/x86_64-w64-mingw32.static.posix/bin/x86_64-w64-mingw32-g++.exe 
@@ -568,7 +568,7 @@ jobs:
         shell: bash
         env:
           DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-          DUCKDB_PLATFORM_RTOOLS: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' && 1 || 0 }}
+          DUCKDB_PLATFORM_RTOOLS: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 1 || 0 }}
           DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
         run: |
           make configure_ci
@@ -576,7 +576,7 @@ jobs:
       - name: Build extension
         env:
           DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-          DUCKDB_PLATFORM_RTOOLS: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' && 1 || 0 }}
+          DUCKDB_PLATFORM_RTOOLS: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 1 || 0 }}
         run: |
           make release
 
@@ -584,7 +584,7 @@ jobs:
         if: ${{ inputs.skip_tests == false }}
         env:
           DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-          DUCKDB_PLATFORM_RTOOLS: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' && 1 || 0 }}
+          DUCKDB_PLATFORM_RTOOLS: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 1 || 0 }}
         run: |
           make test_release
 

--- a/config/distribution_matrix.json
+++ b/config/distribution_matrix.json
@@ -44,7 +44,7 @@
         "vcpkg_triplet": "x64-windows-static-md"
       },
       {
-        "duckdb_arch": "windows_amd64_rtools",
+        "duckdb_arch": "windows_amd64_mingw",
         "vcpkg_triplet": "x64-mingw-static"
       }
     ]


### PR DESCRIPTION
This is not particularly pretty, BUT all in all I think it's the best way forward.

Basically `.github/workflows/_extension_distribution.yml` can be used either by `v1.1.3`(platfrom was called `windows_amd64_rtools`) OR `main` (platform now called `windows_amd64_mingw`), BUT for making use of this end-to-end a newer script to interpret `config/distribution_matrix.json` would have to be provided for `v1.1.x` (if we were to release again).