### PR TITLE
Avoid testing CAPI extensions on _musl outside the container

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -35,7 +35,6 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3'
-      exclude_archs: 'linux_amd64_musl'
 
   extension-template-rust:
     name: Extension template (Rust)

--- a/makefiles/c_api_extensions/base.Makefile
+++ b/makefiles/c_api_extensions/base.Makefile
@@ -125,6 +125,11 @@ ifeq ($(DUCKDB_PLATFORM),linux_amd64)
 	SKIP_TESTS=1
 endif
 
+# _musl tests would need to be run in the container
+ifeq ($(DUCKDB_PLATFORM),linux_amd64_musl)
+	SKIP_TESTS=1
+endif
+
 # The mingw/rtools can not be tested using the python test runner unfortunately
 ifeq ($(DUCKDB_PLATFORM),windows_amd64_rtools)
 	SKIP_TESTS=1


### PR DESCRIPTION
Should fix failure in https://github.com/duckdb/extension-template-c/pull/4