### PR TITLE
Revert cmake version for linux_arm64

### DIFF
--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -9,12 +9,14 @@ RUN apt-get install -y -qq ccache autoconf
 # Setup cross compiler because GH actions does not have open source arm runners yet
 RUN apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-# Install cmake 3.31
-RUN mkdir /cmake_3_31 && \
-    cd /cmake_3_31 && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.31.3/cmake-3.31.3-linux-x86_64.sh && \
-    chmod +x cmake-3.31.3-linux-x86_64.sh && \
-    ./cmake-3.31.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
+# Install cmake 3.21
+# Somehow, recursive-cmake based builds fail when cross-compiling with cmake 3.31,
+# So we revert to using 3.21 for now. We should bisect and investigate this further later.
+RUN mkdir /cmake_3_21 && \
+    cd /cmake_3_21 && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.sh && \
+    chmod +x cmake-3.21.3-linux-x86_64.sh && \
+    ./cmake-3.21.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
     cmake --version
 
 # Install GIT

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -9,14 +9,16 @@ RUN apt-get install -y -qq ccache autoconf
 # Setup cross compiler because GH actions does not have open source arm runners yet
 RUN apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-# Install cmake 3.25
+# Install cmake 3.21
 # Somehow, recursive-cmake based builds fail when cross-compiling with cmake 3.31,
-# So we revert to using 3.25 for now. We should bisect and investigate this further later.
-RUN mkdir /cmake_3_25 && \
-    cd /cmake_3_25 && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.25.3/cmake-3.25.3-linux-x86_64.sh && \
-    chmod +x cmake-3.25.3-linux-x86_64.sh && \
-    ./cmake-3.25.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
+# so we revert to using 3.21 for now. We should investigate this further.
+# I've done some initial bisecting, and it seems like 3.25 also fails.
+# So somewhere between 3.21 and 3.25, something changed in cmake that breaks recursive-cmake CC-builds.
+RUN mkdir /cmake_3_21 && \
+    cd /cmake_3_21 && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.sh && \
+    chmod +x cmake-3.21.3-linux-x86_64.sh && \
+    ./cmake-3.21.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
     cmake --version
 
 # Install GIT

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -9,14 +9,14 @@ RUN apt-get install -y -qq ccache autoconf
 # Setup cross compiler because GH actions does not have open source arm runners yet
 RUN apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-# Install cmake 3.21
+# Install cmake 3.25
 # Somehow, recursive-cmake based builds fail when cross-compiling with cmake 3.31,
-# So we revert to using 3.21 for now. We should bisect and investigate this further later.
-RUN mkdir /cmake_3_21 && \
-    cd /cmake_3_21 && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.sh && \
-    chmod +x cmake-3.21.3-linux-x86_64.sh && \
-    ./cmake-3.21.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
+# So we revert to using 3.25 for now. We should bisect and investigate this further later.
+RUN mkdir /cmake_3_25 && \
+    cd /cmake_3_25 && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.25.3/cmake-3.25.3-linux-x86_64.sh && \
+    chmod +x cmake-3.25.3-linux-x86_64.sh && \
+    ./cmake-3.25.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
     cmake --version
 
 # Install GIT


### PR DESCRIPTION
When compiling duckdb-spatial with the latest extension-ci-tools, linux_arm64 have started failing. Upon further investigation it seems like upgrading the CMake version is the culprit. Specifically, CMake 3.21 is ok, but >= 3.25 breaks.

duckdb-spatial is a bit different than other extension builds in that it doesn't entirely rely on Vcpkg for dependencies but also builds some dependencies using the "recursive cmake" technique. My guess is that something changed in cmake that affected how variables are passed down/interpreted from/to subprocesses which causes the cross-compilation toolchain to be misconfigured for the nested cmake projects, causing them to compile with the host toolchain, which eventually leads to linking errors. 

We should eventually move the rest of spatial to use only vcpkg (I tried, but GDAL doesn't build out-of-the box on the community triplets such as mingw64/wasm) and/or bisect this further, but for now the simplest solution is to downgrade the CMake version we use for this arch. 