### PR TITLE
Pin emsdk to 3.1.71, use latest cmake for arm64 as well

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -658,7 +658,7 @@ jobs:
 
       - uses: mymindstorm/setup-emsdk@v13
         with:
-          version: 3.1.74
+          version: 3.1.71
 
       - name: Setup Rust for cross compilation
         if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;'))}}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -658,7 +658,7 @@ jobs:
 
       - uses: mymindstorm/setup-emsdk@v13
         with:
-          version: 'latest'
+          version: 3.1.74
 
       - name: Setup Rust for cross compilation
         if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;'))}}

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -9,16 +9,12 @@ RUN apt-get install -y -qq ccache autoconf
 # Setup cross compiler because GH actions does not have open source arm runners yet
 RUN apt-get install -y -qq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-# Install cmake 3.21
-# Somehow, recursive-cmake based builds fail when cross-compiling with cmake 3.31,
-# so we revert to using 3.21 for now. We should investigate this further.
-# I've done some initial bisecting, and it seems like 3.25 also fails.
-# So somewhere between 3.21 and 3.25, something changed in cmake that breaks recursive-cmake CC-builds.
-RUN mkdir /cmake_3_21 && \
-    cd /cmake_3_21 && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-linux-x86_64.sh && \
-    chmod +x cmake-3.21.3-linux-x86_64.sh && \
-    ./cmake-3.21.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
+# Install cmake 3.31
+RUN mkdir /cmake_3_31 && \
+    cd /cmake_3_31 && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.31.3/cmake-3.31.3-linux-x86_64.sh && \
+    chmod +x cmake-3.31.3-linux-x86_64.sh && \
+    ./cmake-3.31.3-linux-x86_64.sh --skip-license --prefix=/usr/local && \
     cmake --version
 
 # Install GIT


### PR DESCRIPTION
This PR pins the emsdk version for wasm builds to ~~3.1.74~~ 3.1.71 (4.0.0 was released just a couple days ago), which fixes some compilation issues in duckdb-spatial.

Additionally I've managed to resolve the issues related to updating CMake in arm64 builds properly in duckdb-spatial, so this PR also reverts the changes in https://github.com/duckdb/extension-ci-tools/pull/129. 