### PR TITLE
fix update headers to download correct headers

### DIFF
--- a/makefiles/c_api_extensions/c_cpp.Makefile
+++ b/makefiles/c_api_extensions/c_cpp.Makefile
@@ -134,11 +134,9 @@ build_extension_library_release: check_configure
 #############################################
 ### Misc
 #############################################
-# TODO: switch this to use the $(TARGET_DUCKDB_VERSION) after v1.2.0 is released
-
 BASE_HEADER_URL=
 ifneq ($(TARGET_DUCKDB_VERSION),)
-	BASE_HEADER_URL=https://raw.githubusercontent.com/duckdb/duckdb/refs/heads/$(TARGET_DUCKDB_VERSION)/src/include
+	BASE_HEADER_URL=https://raw.githubusercontent.com/duckdb/duckdb/$(TARGET_DUCKDB_VERSION)/src/include
 else
 	BASE_HEADER_URL=https://raw.githubusercontent.com/duckdb/duckdb/refs/heads/main/src/include
 endif


### PR DESCRIPTION
This allows automatically fetching the headers that are configured using TARGET_DUCKDB_VERSION.

So imagine I want to build an extension specifically for the latest unstable version of duckdb in pip which happens to be commit `5d02d69e5c`. The process will be:

First set these variables in the makefile (or pass them to it)
- `TARGET_DUCKDB_VERSION=5d02d69e5c`
- `USE_UNSTABLE_C_API=1`
- `DUCKDB_TEST_VERSION=1.1.4.dev4889`

Then:
```sh
# installs duckdb==1.1.4.dev4889 and sqllogictestrunner through pip
make configure
# fetches the correct version of duckdb.h and duckdb_extension.h
make update_duckdb_headers
# Builds the extension of abi_type C_STRUCT_UNSTABLE
make debug
# Run the tests on the extension
make test_debug
```

