### PR TITLE
fix: move Docker path under `/mnt` rather than under `/` for additional disk space.

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -177,6 +177,21 @@ jobs:
           fi
           rm package.list
 
+      - name: Restart docker to run on /mnt
+        run: |
+          sudo systemctl stop docker
+
+      - name: Configure Docker with custom data directory
+        run: |
+          sudo mkdir -p /mnt/docker-data
+          echo '{ "data-root": "/mnt/docker-data" }' | sudo tee /etc/docker/daemon.json
+
+      - name: Start Docker with updated storage path
+        run: sudo systemctl start docker
+
+      - name: Verify Docker storage path
+        run: docker info | grep "Docker Root Dir"
+
       - uses: actions/checkout@v4
         name: Checkout override repository
         if: ${{inputs.override_repository != ''}}


### PR DESCRIPTION
Hi DuckDB Team,  

On Linux GitHub runners, Docker currently stores its images under `/var/lib/docker`. However, the available disk space there is limited:  

```
Filesystem      Size  Used Avail Use% Mounted on  
/dev/root        72G   45G   28G  63% /  
tmpfs           7.9G   84K  7.9G   1% /dev/shm  
tmpfs           3.2G  1.1M  3.2G   1% /run  
tmpfs           5.0M     0  5.0M   0% /run/lock  
/dev/sdb16      881M   59M  761M   8% /boot  
/dev/sdb15      105M  6.1M   99M   6% /boot/efi  
/dev/sda1        74G  4.1G   66G   6% /mnt  
tmpfs           1.6G   12K  1.6G   1% /run/user/1001  
```

As shown, Docker is restricted to just 28GB of available space on `/var/lib/docker`. I’m working on an extension that requires more storage, so this patch adjusts the Docker image path to `/mnt/docker-data`, where there's 66GB available.  

This change should help support bigger builds without running into storage issues.  

Thanks for your time reviewing this PR and writing the extension build code.

This is only done for the Linux runners.