### PR TITLE
fix: Addressing `curl` Compatibility in `linux_amd64_gcc4` for Binary Caching  

### DIFF
--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -30,6 +30,16 @@ RUN mkdir /vcpkg && \
 ENV VCPKG_ROOT=/vcpkg
 ENV VCPKG_TOOLCHAIN_PATH=/vcpkg/scripts/buildsystems/vcpkg.cmake
 
+# The version of Curl is so old (curl 7.29.0 (x86_64-redhat-linux-gnu)
+# that vcpkg can't use it for build artifact caching, so install a recent
+# version of curl from vcpkg and symlink it in place.
+RUN curl --version
+RUN /vcpkg/vcpkg integrate install
+RUN /vcpkg/vcpkg install curl[tool]
+RUN mv /usr/bin/curl /usr/bin/curl.old
+RUN ln -s /vcpkg/installed/x64-linux/tools/curl/curl /usr/bin/curl
+RUN curl --version
+
 # Common environment variables
 ENV GEN=ninja
 


### PR DESCRIPTION
Hi DuckDB Team,  

In the `linux_amd64_gcc4` target, the default version of `curl` (7.29.0, released in 2013) is unfortunately incompatible with the command-line arguments required by `vcpkg` for caching binary artifacts using GitHub Actions. This poses a challenge for an upcoming PR that aims to enable binary caching during builds.  

To work around this issue, I’ve configured `vcpkg` to build a more recent version of `curl` directly inside the container and temporarily replace `/usr/bin/curl` with the updated version for the build process. Importantly, this version is only used during the build and is not linked or distributed with the final artifact.  

Additionally, I've raised a request with `vcpkg` to add validation for a minimum `curl` version when using binary caching, which you can find here:  

https://github.com/microsoft/vcpkg/issues/43696  

Thank you!

Best,  
Rusty 