### PR TITLE
fix: add libunwind

### DIFF
--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3
 
 # Setup the basic necessities
 RUN apk update --y -qq
-RUN apk add -qq ccache cmake git ninja ninja-build clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers
+RUN apk add -qq ccache cmake git ninja ninja-build clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers libunwind-dev
 
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
 ARG vcpkg_url


### PR DESCRIPTION
Hi DuckDB Team,

For Rust builds to work with `musl` targets libunwind is required.  This PR adds it.

Rusty
