### PR TITLE
fix: Switch Windows Builds to Use Ninja for Faster Builds  

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -505,6 +505,7 @@ jobs:
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
       CC: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 'gcc' || '' }}
       CXX: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 'g++' || '' }}
+      GEN: ninja
 
     steps:
       - name: Export GitHub Actions cache environment variables
@@ -554,6 +555,10 @@ jobs:
         if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';parser_tools;')}}
         run: |
           choco install winflexbison3
+
+      - name: Install Ninja build tool
+        run: |
+          choco install ninja -y
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
@@ -620,7 +625,14 @@ jobs:
         env:
           DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
           DUCKDB_PLATFORM_RTOOLS: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 1 || 0 }}
+          EXT_FLAGS: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        shell: cmd
         run: |
+          if "%DUCKDB_PLATFORM_RTOOLS%" == "0" (
+            call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
+            REM Rename link.exe to link-git.exe to avoid conflicts with git supplied linker.
+            mv "C:\Program Files\Git\usr\bin\link.exe" "C:\Program Files\Git\usr\bin\link-git.exe"
+          )
           make release
 
       - name: Test extension
@@ -647,6 +659,13 @@ jobs:
             cat $filename;
             echo Done printing logs for $filename
           done
+
+      - name: Move rtools supplied zstd out of the way, so ccache can work
+        if: (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw')
+        shell: cmd
+        run: |
+          mv C:\rtools42\usr\bin\zstd.exe C:\rtools42\usr\bin\zstd-rtools.exe
+
 
   wasm:
     name: DuckDB-Wasm

--- a/makefiles/c_api_extensions/c_cpp.Makefile
+++ b/makefiles/c_api_extensions/c_cpp.Makefile
@@ -72,17 +72,8 @@ ifeq ($(GEN),ninja)
 	MAKE_INVOCATION = ninja
 endif
 
-#############################################
-### Windows weirdness
-#############################################
-
-ifeq ($(OS),Windows_NT)
-	OUTPUT_LIB_PATH_DEBUG=cmake_build/debug/Debug/$(EXTENSION_LIB_FILENAME)
-	OUTPUT_LIB_PATH_RELEASE=cmake_build/release/Release/$(EXTENSION_LIB_FILENAME)
-else
-	OUTPUT_LIB_PATH_DEBUG=cmake_build/debug/$(EXTENSION_LIB_FILENAME)
-	OUTPUT_LIB_PATH_RELEASE=cmake_build/release/$(EXTENSION_LIB_FILENAME)
-endif
+OUTPUT_LIB_PATH_DEBUG=cmake_build/debug/$(EXTENSION_LIB_FILENAME)
+OUTPUT_LIB_PATH_RELEASE=cmake_build/release/$(EXTENSION_LIB_FILENAME)
 
 ifeq ($(DUCKDB_PLATFORM),windows_amd64_rtools)
 	MINGW=1
@@ -91,8 +82,8 @@ ifeq ($(DUCKDB_PLATFORM),windows_amd64_mingw)
 	MINGW=1
 endif
 ifeq ($(MINGW),1)
-	EXTRA_COPY_STEP_DEBUG=$(PYTHON_VENV_BIN) -c "from pathlib import Path;Path('./cmake_build/debug/Debug').mkdir(parents=True, exist_ok=True);import shutil;shutil.copyfile('cmake_build/debug/lib$(EXTENSION_LIB_FILENAME)', '$(OUTPUT_LIB_PATH_DEBUG)')"
-	EXTRA_COPY_STEP_RELEASE=$(PYTHON_VENV_BIN) -c "from pathlib import Path;Path('./cmake_build/release/Release').mkdir(parents=True, exist_ok=True);import shutil;shutil.copyfile('cmake_build/release/lib$(EXTENSION_LIB_FILENAME)', '$(OUTPUT_LIB_PATH_RELEASE)')"
+	EXTRA_COPY_STEP_DEBUG=$(PYTHON_VENV_BIN) -c "from pathlib import Path;Path('./cmake_build/debug').mkdir(parents=True, exist_ok=True);import shutil;shutil.copyfile('cmake_build/debug/lib$(EXTENSION_LIB_FILENAME)', '$(OUTPUT_LIB_PATH_DEBUG)')"
+	EXTRA_COPY_STEP_RELEASE=$(PYTHON_VENV_BIN) -c "from pathlib import Path;Path('./cmake_build/release').mkdir(parents=True, exist_ok=True);import shutil;shutil.copyfile('cmake_build/release/lib$(EXTENSION_LIB_FILENAME)', '$(OUTPUT_LIB_PATH_RELEASE)')"
 endif
 
 CMAKE_WRAPPER=

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -17,14 +17,6 @@ DUCKDB_PATH="/duckdb"
 
 DUCKDB_SRCDIR ?= "./duckdb/"
 
-# For non-MinGW windows the path is slightly different
-ifeq ($(OS),Windows_NT)
-ifneq ($(CXX),g++)
-	TEST_PATH="/test/Release/unittest.exe"
-	DUCKDB_PATH="/Release/duckdb.exe"
-endif
-endif
-
 #### Core extensions, allows easily building one of the core extensions
 ifneq ($(CORE_EXTENSIONS),)
 	CORE_EXTENSION_VAR:=-DCORE_EXTENSIONS="$(CORE_EXTENSIONS)"


### PR DESCRIPTION
Hi DuckDB Team,  

This PR switches Windows builds to use `ninja` with CMake instead of the default generator. The main reason for this is that `ninja` works with `ccache`, which drastically cuts down build times. With this change, Windows builds drop from about 45 minutes to around 4 minutes (most of that is setting up RTools 4.2).  

Just to be clear, this only affects Windows builds and doesn't change the underlying compilers — you can see that by checking the CI job output for the detected compiler paths.  

A couple of small tweaks were also needed:  

1. **RTools Fix:** The `zstd` command from RTools is incompatible with `ccache`, so I added a step to rename it during the build.  
2. **Git Link.exe Issue:** Git on Windows includes a `link.exe` that interferes with Rust builds, so I moved it out of the way to avoid conflicts.  

It took some trial and error to get everything working smoothly.

Cheers,  
Rusty  