### PR TITLE
Add option to build benchmark from extension directory

### DIFF
--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -61,8 +61,12 @@ EXTENSION_FLAGS=-DDUCKDB_EXTENSION_CONFIGS='${EXT_CONFIG}'
 
 BUILD_FLAGS=-DEXTENSION_STATIC_BUILD=1 $(EXTENSION_FLAGS) ${EXT_FLAGS} $(CORE_EXTENSION_VAR) $(OSX_BUILD_FLAG) $(RUST_FLAGS) $(TOOLCHAIN_FLAGS) -DDUCKDB_EXPLICIT_PLATFORM='${DUCKDB_PLATFORM}' -DCUSTOM_LINKER=${CUSTOM_LINKER}
 
+ifeq ($(BUILD_BENCHMARK), 1)
+	BUILD_FLAGS += -DBUILD_BENCHMARKS=1
+endif
+
 debug:
-	mkdir -p  build/debug
+	mkdir -p build/debug
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_DEBUG_FLAGS) -DCMAKE_BUILD_TYPE=Debug -S $(DUCKDB_SRCDIR) -B build/debug
 	cmake --build build/debug --config Debug
 
@@ -162,3 +166,8 @@ output_distribution_matrix:
 
 configure_ci:
 	@echo "configure_ci step is skipped for this extension build..."
+
+benchmark:
+	mkdir -p build/release
+	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) -DBUILD_BENCHMARKS=1 -DCMAKE_BUILD_TYPE=Release -S $(DUCKDB_SRCDIR) -B build/release
+	cmake --build build/release --config Release

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -167,7 +167,3 @@ output_distribution_matrix:
 configure_ci:
 	@echo "configure_ci step is skipped for this extension build..."
 
-benchmark:
-	mkdir -p build/release
-	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) -DBUILD_BENCHMARKS=1 -DCMAKE_BUILD_TYPE=Release -S $(DUCKDB_SRCDIR) -B build/release
-	cmake --build build/release --config Release


### PR DESCRIPTION
Hi there, 

I noticed I couldn't build the benchmark runner from the extension directory, so I added an option to the Makefile to do so.

It doesn't use quite the same flags as the [benchmark command](https://github.com/duckdb/duckdb/blob/f965a9d40cd0fa68d1bbd66a0e535023d1635760/Makefile#L404-L408) in `duckdb/Makefile`, is that important to align?  

Let me know if you find this useful or if I missed something and this is not the way to go :) 

Kind regards, 
Daniel