### PR TITLE
fix: add DuckDB version to ccache key

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -288,9 +288,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./ccache_dir
-          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ steps.ccache_timestamp.outputs.timestamp }}
+          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}-${{ steps.ccache_timestamp.outputs.timestamp }}
           restore-keys: |
-            ccache-extension-distribution-${{ matrix.duckdb_arch }}-
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
 
       - name: Run configure (outside Docker)
         shell: bash
@@ -385,7 +385,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@main
         continue-on-error: true
         with:
-          key: extension-distribution-${{ matrix.duckdb_arch }}
+          key: extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
 
       - uses: actions/setup-python@v5
         with:
@@ -564,7 +564,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@main
         continue-on-error: true
         with:
-          key: ${{ github.job }}-${{ matrix.duckdb_arch }}
+          key: ${{ github.job }}-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
 
       - uses: r-lib/actions/setup-r@v2
         if:  matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw'
@@ -744,7 +744,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@main
         continue-on-error: true
         with:
-          key: ${{ github.job }}-${{ matrix.duckdb_arch }}
+          key: ${{ github.job }}-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
 
       - name: Run configure
         shell: bash


### PR DESCRIPTION
Fix the problem where multiple DuckDB versions would be cached in the same ccache bundle.  This should improve cache hits when building for multiple branches at the same time.