### PR TITLE
Move TestCITools from 1.1.3 to 1.2.0

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -19,7 +19,7 @@ jobs:
       extension_name: quack
       override_repository: duckdb/extension-template
       override_ref: main
-      duckdb_version: v1.1.3
+      duckdb_version: v1.2.0
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp;go;python3'
@@ -43,11 +43,11 @@ jobs:
       extension_name: rusty_quack
       override_repository: duckdb/extension-template-rs
       override_ref: main
-      duckdb_version: v1.1.3
+      duckdb_version: v1.2.0
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'rust;python3'
-      exclude_archs: 'windows_amd64_mingw;linux_amd64_musl' # TODO: remove once fixed upstream
+      exclude_archs: 'windows_amd64_mingw;linux_amd64_musl;wasm_mvp;wasm_eh;wasm_threads' # TODO: remove once fixed upstream
 
   delta-extension-main:
     name: Rust builds (using Delta extension)
@@ -55,9 +55,9 @@ jobs:
     with:
       extension_name: delta
       override_repository: duckdb/duckdb_delta
-      override_ref: 94f887bd539ec0d5ed0d31bd01ff3845cf378a9d
+      override_ref: 846019edcc27000721ff9c4281e85a63d1aa10de
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
-      duckdb_version: v1.1.3
+      duckdb_version: v1.2.0
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_amd64_musl'
       extra_toolchains: 'rust'


### PR DESCRIPTION
This should possibly solve the problems @rustyconover bumped into in https://github.com/duckdb/extension-ci-tools/pull/149 with the test setup.

Unsure if Delta commit needs also changing, for not letting CI run.