### PR TITLE
Make `PYTHON_BIN` configurable

### DIFF
--- a/makefiles/c_api_extensions/base.Makefile
+++ b/makefiles/c_api_extensions/base.Makefile
@@ -16,7 +16,7 @@
 #############################################
 ### Platform dependent config
 #############################################
-PYTHON_BIN=python3
+PYTHON_BIN?=python3
 
 ifeq ($(OS),Windows_NT)
 	EXTENSION_LIB_FILENAME=$(EXTENSION_NAME).dll


### PR DESCRIPTION
The current Makefile assumes Python3 is always `python3`, but it might be `python` (at least, on my Windows desktop). This pull request makes it configurable via envvar, i.e.

```sh
PYTHON_BIN=python make configure
```