### PR TITLE
Set `-DRust_CARGO_TARGET=x86_64-pc-windows-gnu` when `DUCKDB_PLATFORM` is `windows_amd64_{mingw,rtools}`

### DIFF
--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -37,7 +37,7 @@ endif
 #### Windows config
 ifeq ($(DUCKDB_PLATFORM),windows_amd64_mingw)
 	RUST_FLAGS=-DRust_CARGO_TARGET=x86_64-pc-windows-gnu
-ifeq ($(DUCKDB_PLATFORM),windows_amd64_rtools)
+else ifeq ($(DUCKDB_PLATFORM),windows_amd64_rtools)
 	RUST_FLAGS=-DRust_CARGO_TARGET=x86_64-pc-windows-gnu
 endif
 

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -34,6 +34,13 @@ else ifeq ("${OSX_BUILD_ARCH}", "x86_64")
 	RUST_FLAGS=-DRust_CARGO_TARGET=x86_64-apple-darwin
 endif
 
+#### Windows config
+ifeq ($(DUCKDB_PLATFORM),windows_amd64_mingw)
+	RUST_FLAGS=-DRust_CARGO_TARGET=x86_64-pc-windows-gnu
+ifeq ($(DUCKDB_PLATFORM),windows_amd64_rtools)
+	RUST_FLAGS=-DRust_CARGO_TARGET=x86_64-pc-windows-gnu
+endif
+
 #### VCPKG config
 VCPKG_TOOLCHAIN_PATH?=
 ifneq ("${VCPKG_TOOLCHAIN_PATH}", "")


### PR DESCRIPTION
I'm sorry if I miss some context behind the current setup, but it seems `duckdb_extension.Makefile` doesn't properly set the `--target` flag for `cargo`. I'm also not sure if this is sufficient to support these `DUCKDB_PLATFORM`s, but I believe this flag is necessary at least.