### PR TITLE
add vcpkg merging step

### DIFF
--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -42,10 +42,22 @@ else ifeq ($(DUCKDB_PLATFORM),windows_amd64_rtools)
 endif
 
 #### VCPKG config
+EXTENSION_CONFIG_STEP ?=
+
+# Set the toolchain
 VCPKG_TOOLCHAIN_PATH?=
 ifneq ("${VCPKG_TOOLCHAIN_PATH}", "")
-	TOOLCHAIN_FLAGS:=${TOOLCHAIN_FLAGS} -DVCPKG_MANIFEST_DIR='${PROJ_DIR}' -DVCPKG_BUILD=1 -DCMAKE_TOOLCHAIN_FILE='${VCPKG_TOOLCHAIN_PATH}'
+	TOOLCHAIN_FLAGS:=${TOOLCHAIN_FLAGS} -DVCPKG_BUILD=1 -DCMAKE_TOOLCHAIN_FILE='${VCPKG_TOOLCHAIN_PATH}'
 endif
+
+# Add the extension config step which ensures the vcpkg dependencies of all extensions get merged properly
+ifeq (${USE_MERGED_VCPKG_MANIFEST}, 1)
+	EXTENSION_CONFIG_STEP= build/extension_configuration/vcpkg.json
+	VCPKG_MANIFEST_FLAGS:=-DVCPKG_MANIFEST_DIR='${PROJ_DIR}build/extension_configuration'
+else ifneq ("${VCPKG_TOOLCHAIN_PATH}", "")
+	VCPKG_MANIFEST_FLAGS:=-DVCPKG_MANIFEST_DIR='${PROJ_DIR}'
+endif
+
 ifneq ("${VCPKG_TARGET_TRIPLET}", "")
 	TOOLCHAIN_FLAGS:=${TOOLCHAIN_FLAGS} -DVCPKG_TARGET_TRIPLET='${VCPKG_TARGET_TRIPLET}'
 endif
@@ -67,20 +79,29 @@ ifeq ($(BUILD_BENCHMARK), 1)
 	BUILD_FLAGS += -DBUILD_BENCHMARKS=1
 endif
 
-debug:
+debug: ${EXTENSION_CONFIG_STEP}
 	mkdir -p build/debug
-	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_DEBUG_FLAGS) -DCMAKE_BUILD_TYPE=Debug -S $(DUCKDB_SRCDIR) -B build/debug
+	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_DEBUG_FLAGS) $(VCPKG_MANIFEST_FLAGS) -DCMAKE_BUILD_TYPE=Debug -S $(DUCKDB_SRCDIR) -B build/debug
 	cmake --build build/debug --config Debug
 
-release:
+release: ${EXTENSION_CONFIG_STEP}
 	mkdir -p build/release
-	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) -DCMAKE_BUILD_TYPE=Release -S $(DUCKDB_SRCDIR) -B build/release
+	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) $(VCPKG_MANIFEST_FLAGS) -DCMAKE_BUILD_TYPE=Release -S $(DUCKDB_SRCDIR) -B build/release
 	cmake --build build/release --config Release
 
-reldebug:
+reldebug: ${EXTENSION_CONFIG_STEP}
 	mkdir -p build/reldebug
-	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) -DCMAKE_BUILD_TYPE=RelWithDebInfo -S $(DUCKDB_SRCDIR) -B build/reldebug
+	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) $(VCPKG_MANIFEST_FLAGS) -DCMAKE_BUILD_TYPE=RelWithDebInfo -S $(DUCKDB_SRCDIR) -B build/reldebug
 	cmake --build build/reldebug
+
+extension_configuration: build/extension_configuration/vcpkg.json
+
+build/extension_configuration/vcpkg.json:
+	mkdir -p build/extension_configuration
+	mkdir -p duckdb/build/extension_configuration
+	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_DEBUG_FLAGS) -DEXTENSION_CONFIG_BUILD=TRUE -DVCPKG_BUILD=1 -DCMAKE_BUILD_TYPE=Debug -S $(DUCKDB_SRCDIR) -B build/extension_configuration
+	cmake --build build/extension_configuration
+	cp duckdb/build/extension_configuration/vcpkg.json build/extension_configuration/vcpkg.json
 
 # Main tests
 test: test_release


### PR DESCRIPTION
Extensions currently need to inline all vpckg dependencies of extensions that are built for testing.

This PR is the first step to avoid that. I *think* with this we can achieve that extensions can more cleanly depend on extensions that have vcpkg deps themselves.