### PR TITLE
Explicitly install cmake and cmake-data at 3.*

### DIFF
--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -8,6 +8,7 @@ FROM ubuntu:18.04
 RUN apt-get update -y -qq
 RUN apt-get install -y -qq software-properties-common
 RUN apt-get install -y -qq --fix-missing ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client pkg-config autoconf
+RUN apt-get install --allow-downgrades -y -qq 'cmake=3.*' 'cmake-data=3.*'
 RUN apt-get install -y -qq ccache
 
 # Install cmake 3.31

--- a/docker/linux_amd64_gcc4/Dockerfile
+++ b/docker/linux_amd64_gcc4/Dockerfile
@@ -16,6 +16,7 @@ RUN yum install -y perl-IPC-Cmd
 RUN yum install -y ccache
 RUN yum install -y java-11-openjdk-devel maven
 RUN yum install -y libgcc*i686 libstdc++*i686 glibc*i686 libgfortran*i686
+RUN yum install -y 'cmake3*'
 
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
 ARG vcpkg_url

--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3
 
 # Setup the basic necessities
 RUN apk update --y -qq
-RUN apk add -qq ccache cmake git ninja ninja-build clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers libunwind-dev
+RUN apk add -qq ccache 'cmake<4' git ninja ninja-build clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers libunwind-dev
 
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
 ARG vcpkg_url

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:18.04
 RUN apt-get update -y -qq
 RUN apt-get install -y -qq software-properties-common
 RUN apt-get install -y -qq --fix-missing ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client pkg-config
+RUN apt-get install --allow-downgrades -y -qq 'cmake=3.*' 'cmake-data=3.*'
 RUN apt-get install -y -qq ccache autoconf
 
 # Setup cross compiler because GH actions does not have open source arm runners yet


### PR DESCRIPTION
CMake 4.0.0 seems to have broken something related to duckdb/vcpkg (`snappy` ??)

While this is being investigated, this *should* fix the problem, by limiting cmake to 3.* 