### PR TITLE
Fix Linux Amd64 Musl missing Python issues

### DIFF
--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -82,6 +82,9 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Install Python3
 RUN case "$extra_toolchains" in \
   *\;python3\;*) \
-    apk add -qq python3 \
+    apk add -qq python3; \
+    apk info -L python3 | grep bin/python3 \
   ;; \
 esac
+ENV PATH="/usr/bin:${PATH}"
+ENV Python3_EXECUTABLE=/usr/bin/python3


### PR DESCRIPTION
Add the python location to PATH, should fix CI failures like <https://github.com/duckdb/duckdb-iceberg/actions/runs/14476949361/job/40608853089?pr=163> where FindPython fails at runtime in the Docker container.

From the CI below:
```
#15 [11/11] RUN case ";python3;" in   *;python3;*)     apk add -qq python3;     apk info -L python3 | grep bin/python3   ;; esac
#15 1.186 usr/bin/python3
#15 1.249 usr/bin/python3.12
#15 DONE 1.3s
```

Looks like it's correct