### PR TITLE
V1.2.2

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -19,7 +19,7 @@ jobs:
       extension_name: quack
       override_repository: duckdb/extension-template
       override_ref: main
-      duckdb_version: v1.2.1
+      duckdb_version: v1.2.2
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp;go;python3'
@@ -31,7 +31,7 @@ jobs:
       extension_name: capi_quack
       override_repository: duckdb/extension-template-c
       override_ref: main
-      duckdb_version: main
+      duckdb_version: v1.2.2
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3'
@@ -43,7 +43,7 @@ jobs:
       extension_name: rusty_quack
       override_repository: duckdb/extension-template-rs
       override_ref: main
-      duckdb_version: v1.2.0
+      duckdb_version: v1.2.2
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'rust;python3'
@@ -58,6 +58,6 @@ jobs:
       override_ref: 6d626173e9efa6615c25eb08d979d1372100d5db
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
-      duckdb_version: v1.2.1
+      duckdb_version: v1.2.2
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_amd64_musl'
       extra_toolchains: 'rust'

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -55,7 +55,7 @@ jobs:
     with:
       extension_name: delta
       override_repository: duckdb/duckdb_delta
-      override_ref: 6d626173e9efa6615c25eb08d979d1372100d5db
+      override_ref: 90f244b3d572c1692867950b562df8183957b7a8
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       duckdb_version: v1.2.2


### PR DESCRIPTION
Fixes duckdb to version `1.2.2`
Note that the CI for the rust template still fails.
This will be fixed in a separate PR, after the rust extension has been bumped to v1.2.2