### PR TITLE
Update build support for c++20 support

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -569,10 +569,11 @@ jobs:
         run: |
           choco install ninja -y
       
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '3.31.x'
+      - name: Install CMake
+        run: |
+          choco install cmake --version=3.31.0 --force -y
+          refreshenv
+        shell: powershell
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -569,10 +569,10 @@ jobs:
         run: |
           choco install ninja -y
       
-      - name: Set up CMake
-        uses: azyobuzin/setup-cmake@v1
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.31.0'
+          cmake-version: '3.31.x'
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -568,6 +568,11 @@ jobs:
       - name: Install Ninja build tool
         run: |
           choco install ninja -y
+      
+      - name: Set up CMake
+        uses: azyobuzin/setup-cmake@v1
+        with:
+          cmake-version: '3.31.0'
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main

--- a/config/distribution_matrix.json
+++ b/config/distribution_matrix.json
@@ -3,7 +3,7 @@
     "include": [
       {
         "duckdb_arch": "linux_amd64",
-        "container": "ubuntu:18.04",
+        "container": "ubuntu:24.04",
         "vcpkg_target_triplet": "x64-linux-release",
         "vcpkg_host_triplet": "x64-linux-release"
       },
@@ -15,7 +15,7 @@
       },
       {
         "duckdb_arch": "linux_arm64",
-        "container": "ubuntu:18.04",
+        "container": "ubuntu:24.04",
         "vcpkg_target_triplet": "arm64-linux-release",
         "vcpkg_host_triplet": "x64-linux"
       },

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 ###
 # Base image setup

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 # Setup the basic necessities
 RUN apt-get update -y -qq


### PR DESCRIPTION
related to https://github.com/duckdb/extension-ci-tools/issues/180

- updated linux runners to ubuntu 24 LTS (has gcc 13 and c++20 support)
- updated windows runner to use cmake 3.31 for full c++20 support)