### PR TITLE
fix git permission issue in linux ci

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -640,6 +640,13 @@ jobs:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
           vcpkgGitURL: ${{ inputs.vcpkg_url }}
 
+      # disables vcpkg cache to github actions
+      - name: fix vcpkg config
+        run: |
+          if [[ "$VCPKG_BINARY_SOURCES" == "clear;x-gha,readwrite" ]]; then
+            echo "VCPKG_BINARY_SOURCES=" >> $GITHUB_ENV
+          fi
+
       - name: Run configure
         shell: bash
         env:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -436,6 +436,7 @@ jobs:
         with:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
           vcpkgGitURL: ${{ inputs.vcpkg_url }}
+          doNotCache: ${{ vars.VCPKG_BINARY_SOURCES == '' }} # disable the default caching behaviour: it's broken
 
       - name: Install Rust cross compile dependency
         if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && matrix.osx_build_arch == 'x86_64'}}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -642,6 +642,7 @@ jobs:
 
       # disables vcpkg cache to github actions
       - name: fix vcpkg config
+        shell: bash
         run: |
           if [[ "$VCPKG_BINARY_SOURCES" == "clear;x-gha,readwrite" ]]; then
             echo "VCPKG_BINARY_SOURCES=" >> $GITHUB_ENV

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -436,7 +436,6 @@ jobs:
         with:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
           vcpkgGitURL: ${{ inputs.vcpkg_url }}
-          doNotCache: ${{ vars.VCPKG_BINARY_SOURCES == '' }} # disable the default caching behaviour: it's broken
 
       - name: Install Rust cross compile dependency
         if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && matrix.osx_build_arch == 'x86_64'}}
@@ -474,6 +473,13 @@ jobs:
           echo "CFLAGS=-I/opt/homebrew/opt/libomp/include" >> $GITHUB_ENV
           echo "CPPFLAGS=-I/opt/homebrew/opt/libomp/include" >> $GITHUB_ENV
           echo "CXXFLAGS=-I/opt/homebrew/opt/libomp/include" >> $GITHUB_ENV
+
+      # disables vcpkg cache to github actions
+      - name: fix vcpkg config
+        run: |
+          if [[ "$VCPKG_BINARY_SOURCES" == "clear;x-gha,readwrite" ]]; then
+            echo "VCPKG_BINARY_SOURCES=" >> $GITHUB_ENV
+          fi
 
       - name: Run configure
         shell: bash

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -43,6 +43,9 @@ ENV GEN=ninja
 VOLUME /duckdb_build_dir
 WORKDIR /duckdb_build_dir
 
+# Allow git access to the mounted volume
+RUN git config --global --add safe.directory "*"
+
 # Mount for ccache to allow restoring ccache in GH actions
 VOLUME /ccache_dir
 ENV CCACHE_DIR=/ccache_dir

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -43,6 +43,9 @@ ENV GEN=ninja
 VOLUME /duckdb_build_dir
 WORKDIR /duckdb_build_dir
 
+# Allow git access to the mounted volume
+RUN git config --global --add safe.directory "*"
+
 # Mount for ccache to allow restoring ccache in GH actions
 VOLUME /ccache_dir
 ENV CCACHE_DIR=/ccache_dir


### PR DESCRIPTION
Fixes a problem introduced by https://github.com/duckdb/extension-ci-tools/pull/190 which migrates to a new dockerfile.

Upgrading the image caused a new git version to be used, which now requires setting the git permission thingy.

Also, I've disabled vcpkg caching through github actions which was causing failures. This is to be replaced with s3 based caching