### PR TITLE
Add code quality workflows

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -81,4 +81,4 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3'
-    secrets: inherit
+

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -69,3 +69,18 @@ jobs:
       save_cache: ${{ github.event_name != 'pull_request' }}
       vcpkg_binary_sources: ${{ github.event_name == 'push' && vars.VCPKG_BINARY_SOURCES || '' }}
     secrets: inherit
+
+  code-quality:
+    name: Code Quality
+    uses: ./.github/workflows/_extension_code_quality.yml
+    with:
+      extension_name: quack
+      override_repository: duckdb/extension-template
+      override_ref: main
+      duckdb_version: v1.3.0
+      override_ci_tools_repository: ${{ github.repository }}
+      ci_tools_version: ${{ github.sha }}
+      extra_toolchains: 'python3'
+      save_cache: ${{ github.event_name != 'pull_request' }}
+      vcpkg_binary_sources: ${{ github.event_name == 'push' && vars.VCPKG_BINARY_SOURCES || '' }}
+    secrets: inherit

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -75,11 +75,10 @@ jobs:
     uses: ./.github/workflows/_extension_code_quality.yml
     with:
       extension_name: quack
-      override_repository: dtenwolde/extension-template
+      override_repository: duckdb/extension-template
       override_ref: main
       duckdb_version: v1.3.0
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3'
-      cpkg_binary_sources: ${{ github.event_name == 'push' && vars.VCPKG_BINARY_SOURCES || '' }}
     secrets: inherit

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -81,6 +81,5 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3'
-      format_checks: 'format'
-      vcpkg_binary_sources: ${{ github.event_name == 'push' && vars.VCPKG_BINARY_SOURCES || '' }}
+      cpkg_binary_sources: ${{ github.event_name == 'push' && vars.VCPKG_BINARY_SOURCES || '' }}
     secrets: inherit

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -82,5 +82,6 @@ jobs:
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3'
       save_cache: ${{ github.event_name != 'pull_request' }}
+      format_checks: 'format;tidy'
       vcpkg_binary_sources: ${{ github.event_name == 'push' && vars.VCPKG_BINARY_SOURCES || '' }}
     secrets: inherit

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -81,7 +81,6 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3'
-      save_cache: ${{ github.event_name != 'pull_request' }}
       format_checks: 'format;tidy'
       vcpkg_binary_sources: ${{ github.event_name == 'push' && vars.VCPKG_BINARY_SOURCES || '' }}
     secrets: inherit

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -75,12 +75,12 @@ jobs:
     uses: ./.github/workflows/_extension_code_quality.yml
     with:
       extension_name: quack
-      override_repository: duckdb/extension-template
+      override_repository: dtenwolde/extension-template
       override_ref: main
       duckdb_version: v1.3.0
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3'
-      format_checks: 'format;tidy'
+      format_checks: 'format'
       vcpkg_binary_sources: ${{ github.event_name == 'push' && vars.VCPKG_BINARY_SOURCES || '' }}
     secrets: inherit

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -75,7 +75,7 @@ jobs:
     uses: ./.github/workflows/_extension_code_quality.yml
     with:
       extension_name: quack
-      override_repository: duckdb/extension-template
+      override_repository: dtenwolde/extension-template
       override_ref: main
       duckdb_version: v1.3.0
       override_ci_tools_repository: ${{ github.repository }}

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -75,7 +75,7 @@ jobs:
     uses: ./.github/workflows/_extension_code_quality.yml
     with:
       extension_name: quack
-      override_repository: dtenwolde/extension-template
+      override_repository: duckdb/extension-template
       override_ref: main
       duckdb_version: v1.3.0
       override_ci_tools_repository: ${{ github.repository }}

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -68,7 +68,6 @@ jobs:
       - name: Checkout extension-ci-tools
         uses: actions/checkout@v4
         with:
-         path: 'extension-ci-tools'
          repository: ${{ inputs.override_ci_tools_repository }}
          ref: ${{ inputs.ci_tools_version }}
 
@@ -86,7 +85,6 @@ jobs:
           clang-format --version
           clang-format --dump-config
           black --version
-          ls extension-ci-tools
           make format-check
 
       - name: Generated Check

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -65,6 +65,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout extension-ci-tools
+        uses: actions/checkout@v4
+        with:
+         path: extension-ci-tools
+         repository: ${{ inputs.override_ci_tools_repository }}
+         ref: ${{ inputs.ci_tools_version }}
+
       - name: Install
         shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-format-11 && sudo pip3 install cmake-format 'black==24.*' cxxheaderparser pcpp 'clang_format==11.0.1'

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -36,10 +36,10 @@ on:
       GH_TOKEN:
         required: false
   repository_dispatch:
-  push:
-    paths-ignore:
-      - '**.md'
-      - '.github/workflows/**'
+#  push:
+#    paths-ignore:
+#      - '**.md'
+#      - '.github/workflows/**'
   merge_group:
   pull_request:
     types: [opened, reopened]

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -86,8 +86,7 @@ jobs:
           clang-format --version
           clang-format --dump-config
           black --version
-          cd extension-ci-tools
-          ls
+          ls extension-ci-tools/makefiles
           make format-check
 
       - name: Generated Check

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -118,8 +118,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        name: Checkout override repository
+        if: ${{inputs.override_repository != ''}}
+        with:
+          repository: ${{ inputs.override_repository }}
+          ref: ${{ inputs.override_ref }}
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - uses: actions/checkout@v4
+        name: Checkout current repository
+        if: ${{inputs.override_repository == ''}}
         with:
           fetch-depth: 0
+          submodules: 'recursive'
+
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
+        with:
+          path: 'extension-ci-tools'
+          ref: ${{ inputs.ci_tools_version }}
+          repository: ${{ inputs.override_ci_tools_repository }}
 
       - name: Install
         shell: bash

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -1,8 +1,9 @@
 name: CodeQuality
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      explicit_checks:
+      duckdb_version:
+        required: true
         type: string
   repository_dispatch:
   push:
@@ -59,31 +60,6 @@ jobs:
         run: |
           make generate-files
           git diff --exit-code
-
-  enum-check:
-    name: C Enum Integrity Check
-    needs: format-check
-    runs-on: ubuntu-22.04
-
-    env:
-      CC: gcc-10
-      CXX: g++-10
-      GEN: ninja
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install python dependencies
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        shell: bash
-        run: python -m pip install cxxheaderparser pcpp
-
-      - name: Verify C enum integrity
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        shell: bash
-        run: python scripts/verify_enum_integrity.py src/include/duckdb.h
 
   tidy-check:
     name: Tidy Check

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -10,16 +10,16 @@ on:
         required: true
       override_repository:
         type: string
-        required: true
+        required: false
       override_ref:
         type: string
-        required: true
+        required: false
       duckdb_version:
         type: string
         required: true
       override_ci_tools_repository:
         type: string
-        required: true
+        required: false
       ci_tools_version:
         type: string
         required: true

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -86,6 +86,7 @@ jobs:
           clang-format --version
           clang-format --dump-config
           black --version
+          cd extension-ci-tools
           ls
           make format-check
 

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -95,12 +95,6 @@ jobs:
           black --version
           make format-check
 
-      - name: Generated Check
-        shell: bash
-        run: |
-          make generate-files
-          git diff --exit-code
-
   tidy-check:
     name: Tidy Check
     runs-on: ubuntu-24.04

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -27,6 +27,10 @@ on:
       extra_toolchains:
         type: string
         required: false
+      format_checks:
+        type: string
+        required: true
+        default: "format;tidy"
     secrets:
       GH_TOKEN:
         required: false
@@ -48,6 +52,7 @@ env:
 jobs:
   format-check:
     name: Format Check
+    if: contains(inputs.format_checks, 'format')
     runs-on: ubuntu-22.04
 
     env:
@@ -97,6 +102,7 @@ jobs:
 
   tidy-check:
     name: Tidy Check
+    if: contains(inputs.format_checks, 'tidy')
     runs-on: ubuntu-24.04
 
     env:

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -26,12 +26,6 @@ on:
       extra_toolchains:
         type: string
         required: false
-      save_cache:
-        type: boolean
-        required: false
-      vcpkg_binary_sources:
-        type: string
-        required: false
     secrets:
       GH_TOKEN:
         required: false
@@ -85,6 +79,7 @@ jobs:
           clang-format --version
           clang-format --dump-config
           black --version
+          ls
           make format-check
 
       - name: Generated Check

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -92,6 +92,9 @@ jobs:
           clang-format --version
           clang-format --dump-config
           black --version
+          ls
+          git log
+          cat extension-ci-tools/makefiles/duckdb_extension.Makefile
           make format-check
 
       - name: Generated Check

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout extension-ci-tools
         uses: actions/checkout@v4
         with:
-         path: extension-ci-tools
+         path: 'extension-ci-tools'
          repository: ${{ inputs.override_ci_tools_repository }}
          ref: ${{ inputs.ci_tools_version }}
 
@@ -86,7 +86,7 @@ jobs:
           clang-format --version
           clang-format --dump-config
           black --version
-          ls extension-ci-tools/makefiles
+          ls extension-ci-tools
           make format-check
 
       - name: Generated Check

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -107,7 +107,6 @@ jobs:
   tidy-check:
     name: Tidy Check
     runs-on: ubuntu-24.04
-    needs: format-check
 
     env:
       CC: gcc

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -20,6 +20,7 @@ on:
       override_ci_tools_repository:
         type: string
         required: false
+        default: "duckdb/extension-ci-tools"
       ci_tools_version:
         type: string
         required: true

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -1,0 +1,133 @@
+name: CodeQuality
+on:
+  workflow_dispatch:
+    inputs:
+      explicit_checks:
+        type: string
+  repository_dispatch:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '.github/workflows/**'
+  merge_group:
+  pull_request:
+    types: [opened, reopened]
+    paths-ignore:
+      - '**.md'
+      - '.github/workflows/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+jobs:
+  format-check:
+    name: Format Check
+    runs-on: ubuntu-22.04
+
+    env:
+      CC: gcc-10
+      CXX: g++-10
+      GEN: ninja
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install
+        shell: bash
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-format-11 && sudo pip3 install cmake-format 'black==24.*' cxxheaderparser pcpp 'clang_format==11.0.1'
+
+      - name: List Installed Packages
+        shell: bash
+        run: pip3 freeze
+
+      - name: Format Check
+        shell: bash
+        run: |
+          clang-format --version
+          clang-format --dump-config
+          black --version
+          make format-check-silent
+
+      - name: Generated Check
+        shell: bash
+        run: |
+          make generate-files
+          git diff --exit-code
+
+  enum-check:
+    name: C Enum Integrity Check
+    needs: format-check
+    runs-on: ubuntu-22.04
+
+    env:
+      CC: gcc-10
+      CXX: g++-10
+      GEN: ninja
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install python dependencies
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        shell: bash
+        run: python -m pip install cxxheaderparser pcpp
+
+      - name: Verify C enum integrity
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        shell: bash
+        run: python scripts/verify_enum_integrity.py src/include/duckdb.h
+
+  tidy-check:
+    name: Tidy Check
+    runs-on: ubuntu-24.04
+    needs: format-check
+
+    env:
+      CC: gcc
+      CXX: g++
+      GEN: ninja
+      TIDY_THREADS: 4
+      TIDY_CHECKS: ${{ inputs.explicit_checks && inputs.explicit_checks || '' }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install
+        shell: bash
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-tidy && sudo pip3 install pybind11[global] --break-system-packages
+
+      - name: Setup Ccache
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          key: ${{ github.job }}
+          save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
+
+      - name: Download clang-tidy-cache
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
+        shell: bash
+        run: |
+          set -e
+          curl -Lo /tmp/clang-tidy-cache https://github.com/ejfitzgerald/clang-tidy-cache/releases/download/v0.4.0/clang-tidy-cache-linux-amd64
+          md5sum /tmp/clang-tidy-cache | grep 880b290d7bbe7c1fb2a4f591f9a86cc1
+          chmod +x /tmp/clang-tidy-cache
+
+      - name: Tidy Check
+        shell: bash
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
+        run: make tidy-check TIDY_BINARY=/tmp/clang-tidy-cache
+
+      - name: Tidy Check Diff
+        shell: bash
+        if: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/feature' }}
+        run: make tidy-check-diff

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -57,8 +57,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        name: Checkout override repository
+        if: ${{inputs.override_repository != ''}}
+        with:
+          repository: ${{ inputs.override_repository }}
+          ref: ${{ inputs.override_ref }}
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - uses: actions/checkout@v4
+        name: Checkout current repository
+        if: ${{inputs.override_repository == ''}}
         with:
           fetch-depth: 0
+          submodules: 'recursive'
 
       - name: Checkout extension-ci-tools
         uses: actions/checkout@v4

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -79,7 +79,7 @@ jobs:
           clang-format --version
           clang-format --dump-config
           black --version
-          make format-check-silent
+          make format-check
 
       - name: Generated Check
         shell: bash

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -93,9 +93,6 @@ jobs:
           clang-format --version
           clang-format --dump-config
           black --version
-          ls
-          git log
-          cat extension-ci-tools/makefiles/duckdb_extension.Makefile
           make format-check
 
       - name: Generated Check

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -20,7 +20,7 @@ on:
       override_ci_tools_repository:
         type: string
         required: false
-        default: "duckdb/extension-ci-tools"
+        default: "dtenwolde/extension-ci-tools"
       ci_tools_version:
         type: string
         required: true

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -140,28 +140,6 @@ jobs:
         shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-tidy && sudo pip3 install pybind11[global] --break-system-packages
 
-      - name: Setup Ccache
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
-        uses: hendrikmuhs/ccache-action@main
-        with:
-          key: ${{ github.job }}
-          save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
-
-      - name: Download clang-tidy-cache
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
-        shell: bash
-        run: |
-          set -e
-          curl -Lo /tmp/clang-tidy-cache https://github.com/ejfitzgerald/clang-tidy-cache/releases/download/v0.4.0/clang-tidy-cache-linux-amd64
-          md5sum /tmp/clang-tidy-cache | grep 880b290d7bbe7c1fb2a4f591f9a86cc1
-          chmod +x /tmp/clang-tidy-cache
-
-      - name: Tidy Check
-        shell: bash
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
-        run: make tidy-check TIDY_BINARY=/tmp/clang-tidy-cache
-
       - name: Tidy Check Diff
         shell: bash
-        if: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/feature' }}
         run: make tidy-check

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -36,10 +36,6 @@ on:
       GH_TOKEN:
         required: false
   repository_dispatch:
-#  push:
-#    paths-ignore:
-#      - '**.md'
-#      - '.github/workflows/**'
   merge_group:
   pull_request:
     types: [opened, reopened]

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -72,11 +72,12 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - name: Checkout extension-ci-tools
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
         with:
-         repository: "dtenwolde/extension-ci-tools"
-         ref: "code-quality-v2"
+          path: 'extension-ci-tools'
+          ref: ${{ inputs.ci_tools_version }}
+          repository: ${{ inputs.override_ci_tools_repository }}
 
       - name: Install
         shell: bash

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -20,7 +20,7 @@ on:
       override_ci_tools_repository:
         type: string
         required: false
-        default: "dtenwolde/extension-ci-tools"
+        default: "duckdb/extension-ci-tools"
       ci_tools_version:
         type: string
         required: true

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -29,7 +29,7 @@ on:
         required: false
       format_checks:
         type: string
-        required: true
+        required: false
         default: "format;tidy"
     secrets:
       GH_TOKEN:

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -167,4 +167,4 @@ jobs:
       - name: Tidy Check Diff
         shell: bash
         if: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/feature' }}
-        run: make tidy-check-diff
+        run: make tidy-check

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -2,12 +2,39 @@ name: CodeQuality
 on:
   workflow_call:
     inputs:
-      duckdb_version:
-        required: true
+      explicit_checks:
         type: string
+        required: false
       extension_name:
         type: string
         required: true
+      override_repository:
+        type: string
+        required: true
+      override_ref:
+        type: string
+        required: true
+      duckdb_version:
+        type: string
+        required: true
+      override_ci_tools_repository:
+        type: string
+        required: true
+      ci_tools_version:
+        type: string
+        required: true
+      extra_toolchains:
+        type: string
+        required: false
+      save_cache:
+        type: boolean
+        required: false
+      vcpkg_binary_sources:
+        type: string
+        required: false
+    secrets:
+      GH_TOKEN:
+        required: false
   repository_dispatch:
   push:
     paths-ignore:

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -79,7 +79,7 @@ jobs:
           clang-format --version
           clang-format --dump-config
           black --version
-          ls
+          ls extension-ci-tools
           make format-check
 
       - name: Generated Check

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -86,6 +86,7 @@ jobs:
           clang-format --version
           clang-format --dump-config
           black --version
+          ls
           make format-check
 
       - name: Generated Check

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -5,6 +5,9 @@ on:
       duckdb_version:
         required: true
         type: string
+      extension_name:
+        type: string
+        required: true
   repository_dispatch:
   push:
     paths-ignore:

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -80,7 +80,7 @@ jobs:
           clang-format --version
           clang-format --dump-config
           black --version
-          ls extension-ci-tools
+          ls 
           make format-check
 
       - name: Generated Check

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Checkout extension-ci-tools
         uses: actions/checkout@v4
         with:
-         repository: ${{ inputs.override_ci_tools_repository }}
-         ref: ${{ inputs.ci_tools_version }}
+         repository: "dtenwolde/extension-ci-tools"
+         ref: "code-quality-v2"
 
       - name: Install
         shell: bash
@@ -80,7 +80,6 @@ jobs:
           clang-format --version
           clang-format --dump-config
           black --version
-          ls 
           make format-check
 
       - name: Generated Check


### PR DESCRIPTION
Related PRs: https://github.com/duckdb/extension-template/pull/126

This PR introduces two new code quality workflows: `format-check` and `tidy-check`.  

The workflows are enabled by default, but can be disabled by extension builders by removing one or more option(s): `format_checks: 'format;tidy'`. 

It also allows us to easily expand the quality check workflow in the future if need be. 

