### PR TITLE
allow building vcpkg deps automatically

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -98,6 +98,11 @@ on:
         required: false
         type: string
         default: ""
+      # Experimental option to allow automatically building the vcpkg dependencies of duckdb extensions that are used for testing
+      use_merged_vcpkg_manifest:
+        required: false
+        type: string
+        default: ""
       rust_logs:
         required: false
         type: boolean
@@ -290,6 +295,7 @@ jobs:
         run: |
           cat <<-EOF > docker_env.txt
           VCPKG_BINARY_SOURCES=$VCPKG_BINARY_SOURCES
+          USE_MERGED_VCPKG_MANIFEST=${{ inputs.use_merged_vcpkg_manifest }}
           AWS_ACCESS_KEY_ID=${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY=${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL=${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
@@ -401,6 +407,7 @@ jobs:
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
+      USE_MERGED_VCPKG_MANIFEST: ${{ inputs.use_merged_vcpkg_manifest }}
       # VCPKG caching
       AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
@@ -588,6 +595,7 @@ jobs:
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
+      USE_MERGED_VCPKG_MANIFEST: ${{ inputs.use_merged_vcpkg_manifest }}
       # VCPKG caching
       AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
@@ -794,6 +802,7 @@ jobs:
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      USE_MERGED_VCPKG_MANIFEST: ${{ inputs.use_merged_vcpkg_manifest }}
       # VCPKG caching
       AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
With this, extensions no longer need to inline the vcpkg dependencies of the extensions that they rely on for building. It's sortof a hotfix for the fact that we do not have a proper package manager.

# Why 
For development and in CI it is nice to be able to easily specify which extension dependencies are built along with and extension. For example for delta, we now build various other extensions like tpch, tpcds, aws, and azure. However, building all these extensions takes quite a long time both during development and in CI, even with vcpkg binary caching and ccache.

# How
The solution here is to allow extensions to control which set of extensions are built. This requires two parts:

Firstly, the extensions needs to specify which extensions it needs for testing. These are either part of the `default` set or the `full` set of extension dependencies. The idea is that some extensions need other extensions to do any meaningful work. For example the iceberg extension can do almost nothing useful without the `avro` extension and `parquet` extension. These would be added to the `default` set. Other extensions such as `aws` or `azure` might only be necessary to run some specific tests that you don't always run anyway. These extensions will go in the `full` set.

Secondly, currently we have to manually merge the vcpkg dependencies of the test extension dependencies in the main vcpkg.json file. This is very ugly and also problematic, because it means that even if we were not not build some extensions, their vcpkg deps would still get built. Therefore this PR also finished the work started in https://github.com/duckdb/extension-ci-tools/pull/193 by adding the vcpkg manifest merging feature to CI

# How to use
The idea being that an extension can specify the extensions to include in a build like:

```sh
# default: build a minimal set of extensions that strikes a balance between 
# build time and ability to execute enough tests
BUILD_TEST_EXTENSION_DEPS='' make debug
BUILD_TEST_EXTENSION_DEPS='default' make debug

# build none of the test extension dependencies: this might result in most of the tests to be skipped
BUILD_TEST_EXTENSION_DEPS='none' make debug

# to be able to run all the tests, we need the full test of test extension dependencies
BUILD_TEST_EXTENSION_DEPS='full' make debug
```

To implement this extensions can either:
add this to their makefile:

```makefile
DEFAULT_TEST_EXTENSION_DEPS=tpch
FULL_TEST_EXTENSION_DEPS=tpcds;icu
```

Or in their `extension_config.cmake` file:
```cmake
if ("${BUILD_EXTENSION_TEST_DEPS}" STREQUAL "default")	
	duckdb_extension_load(json); 
endif() 
if ("${BUILD_EXTENSION_TEST_DEPS}" STREQUAL "full" OR "${BUILD_EXTENSION_TEST_DEPS}" STREQUAL "default" )	
	duckdb_extension_load(tpch);
	duckdb_extension_load(tpcds);
	duckdb_extension_load(aws);
	duckdb_extension_load(azure); 
endif() 
```

