### PR TITLE
add ninja path on musl

### DIFF
--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir /vcpkg && \
     VCPKG_FORCE_SYSTEM_BINARIES=1 ./bootstrap-vcpkg.sh
 ENV VCPKG_ROOT=/vcpkg
 ENV VCPKG_TOOLCHAIN_PATH=/vcpkg/scripts/buildsystems/vcpkg.cmake
-ENV PATH="${VCPKG_ROOT}:${PATH}"
+ENV PATH="${VCPKG_ROOT}:/usr/lib/ninja-build/bin:${PATH}"
 
 # Common environment variables
 ENV GEN=ninja

--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -22,7 +22,10 @@ RUN mkdir /vcpkg && \
     VCPKG_FORCE_SYSTEM_BINARIES=1 ./bootstrap-vcpkg.sh
 ENV VCPKG_ROOT=/vcpkg
 ENV VCPKG_TOOLCHAIN_PATH=/vcpkg/scripts/buildsystems/vcpkg.cmake
-ENV PATH="${VCPKG_ROOT}:/usr/lib/ninja-build/bin:${PATH}"
+ENV PATH="${VCPKG_ROOT}:${PATH}"
+
+# Add ninja to path
+ENV PATH="/usr/lib/ninja-build/bin:${PATH}"
 
 # Common environment variables
 ENV GEN=ninja


### PR DESCRIPTION
Installing ninja doesn't add it to the path on musl, so it uses some old system version by default (I think `samurai`) which doesn't work for some vcpkg dependencies that require a newer version. Adding the path explicitly fixes it. 