### PR TITLE
feat: Add Support for Custom Environment Variables for Extension Testing

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -131,6 +131,10 @@ on:
         required: false
         type: boolean
         default: false
+      test_env_vars:
+        required: false
+        type: string
+        default: "{}"
 
 env:
   VCPKG_BINARY_SOURCES: ${{inputs.vcpkg_binary_sources == '' && 'clear;http,https://vcpkg-cache.duckdb.org,read' || inputs.vcpkg_binary_sources }}
@@ -312,6 +316,7 @@ jobs:
           EXTENSION_CANONICAL=${{ inputs.extension_canonical }}
           LINUX_CI_IN_DOCKER=1
           EOF
+          echo '${{ inputs.test_env_vars }}'| jq -r 'to_entries|map("\(.key)=\(.value)")|.[]' >> docker_env.txt
 
       - name: Generate timestamp for Ccache entry
         shell: cmake -P {0}
@@ -378,6 +383,7 @@ jobs:
           DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
           LINUX_CI_IN_DOCKER: 0
         run: |
+          eval "$(jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_env_vars}}')"
           make test_release
 
       - uses: actions/upload-artifact@v4
@@ -565,6 +571,7 @@ jobs:
         if: ${{ matrix.osx_build_arch == 'arm64' && inputs.skip_tests == false }}
         shell: bash
         run: |
+          eval "$(jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_env_vars}}')"
           make test_release
 
       - uses: actions/upload-artifact@v4
@@ -669,6 +676,10 @@ jobs:
         run: |
           choco install ninja -y
 
+      - name: Install jq
+        run: |
+          choco install jq -y
+
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
         continue-on-error: true
@@ -762,10 +773,12 @@ jobs:
 
       - name: Test extension
         if: ${{ inputs.skip_tests == false }}
+        shell: bash
         env:
           DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
           DUCKDB_PLATFORM_RTOOLS: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 1 || 0 }}
         run: |
+          eval "$(jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_env_vars}}')"
           make test_release
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -131,7 +131,7 @@ on:
         required: false
         type: boolean
         default: false
-      test_env_vars:
+      test_config:
         required: false
         type: string
         default: "{}"
@@ -316,7 +316,7 @@ jobs:
           EXTENSION_CANONICAL=${{ inputs.extension_canonical }}
           LINUX_CI_IN_DOCKER=1
           EOF
-          echo '${{ inputs.test_env_vars }}'| jq -r 'to_entries|map("\(.key)=\(.value)")|.[]' >> docker_env.txt
+          echo '${{ inputs.test_config }}'| jq -r '.test_env_variables // {} | to_entries | map("\(.key)=\(.value)")|.[]' >> docker_env.txt
 
       - name: Generate timestamp for Ccache entry
         shell: cmake -P {0}
@@ -383,7 +383,7 @@ jobs:
           DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
           LINUX_CI_IN_DOCKER: 0
         run: |
-          eval "$(jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_env_vars}}')"
+          eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
           make test_release
 
       - uses: actions/upload-artifact@v4
@@ -571,7 +571,7 @@ jobs:
         if: ${{ matrix.osx_build_arch == 'arm64' && inputs.skip_tests == false }}
         shell: bash
         run: |
-          eval "$(jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_env_vars}}')"
+          eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
           make test_release
 
       - uses: actions/upload-artifact@v4
@@ -778,7 +778,7 @@ jobs:
           DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
           DUCKDB_PLATFORM_RTOOLS: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 1 || 0 }}
         run: |
-          eval "$(jq -r 'to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_env_vars}}')"
+          eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
           make test_release
 
       - uses: actions/upload-artifact@v4

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -8,6 +8,7 @@ RUN yum install -y ccache
 RUN yum install -y java-11-openjdk-devel maven
 RUN yum install -y wget
 RUN yum install -y kernel-headers
+RUN yum install -y jq
 
 # We need a recent CMake
 RUN mkdir /cmake_4_02 && \

--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3
 
 # Setup the basic necessities
 RUN apk update --y -qq
-RUN apk add -qq ccache cmake git ninja ninja-build clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers libunwind-dev
+RUN apk add -qq ccache cmake git ninja ninja-build clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers libunwind-dev jq
 RUN wget https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/aws-cli-2.22.10-r0.apk
 RUN apk add --allow-untrusted aws-cli-2.22.10-r0.apk
 

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -8,6 +8,8 @@ RUN yum install -y ccache
 RUN yum install -y java-11-openjdk-devel maven
 RUN yum install -y wget
 RUN yum install -y kernel-headers
+RUN yum install -y jq
+
 
 
 # We need a recent CMake


### PR DESCRIPTION
Hi DuckDB Team,

I hope you're well. I'd like to propose an enhancement to the extension testing workflow that would provide additional flexibility.

### Background

While developing the test suite for the Airport extension, I've encountered a need to pass custom environment variables to the testing environment. This capability would allow for more flexible configuration of test parameters, particularly for specifying server URLs during testing.

### Use Case

The primary use case involves allowing developers to easily configure the test server URL:

- **Local Development**: Developers can point tests to a server running locally on their development machine
- **CI/CD Pipeline**: For extension releases, tests can be configured to run against our production server hosted on Google Cloud
- **Flexibility**: Other developers may have different server configurations they'd like to test against

### Proposed Solution

I'd like to add a `test_env_vars` input parameter to the GitHub Action workflow. This would:

- Accept environment variables specified in JSON format
- Use `jq` to parse the JSON configuration
  - The reason I used JSON is to allow multiple environment variables to be able to be set, GitHub Actions doesn't allow dictionary types to be passed.
- Export the variables to the appropriate environment:
  - Docker environment for Linux builds
  - Native environment for macOS and Windows builds

### Example Use

```yaml
jobs:
  duckdb-stable-build:
    name: Build extension binaries
    uses: rustyconover/extension-ci-tools/.github/workflows/_extension_distribution.yml@4dca80c264233c4914f2ed51e0c5d764f9a828e3
    with:
      duckdb_version: main
      extension_name: airport
      ci_tools_version: 4dca80c264233c4914f2ed51e0c5d764f9a828e3
      extra_toolchains: parser_tools
      exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;"
      vcpkg_binary_sources: ${{ vars.VCPKG_BINARY_SOURCES }}
      test_env_vars: >
        {
          "AIRPORT_TEST_SERVER": "grpc+tls://airport-ci.query.farm"
        }
    secrets:
      VCPKG_CACHING_AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
      VCPKG_CACHING_AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
      VCPKG_CACHING_AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
      VCPKG_CACHING_AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION}}
```

### Benefits

This enhancement would provide a clean, standardized way for extension developers to customize their testing environments without requiring workflow modifications for each specific use case.

I'd be happy to discuss this proposal further or provide additional context if needed. Thank you for considering this PR!

Rusty