### PR TITLE
Add new triplet for Windows compatible with VS2019

### DIFF
--- a/config/distribution_matrix.json
+++ b/config/distribution_matrix.json
@@ -41,8 +41,8 @@
     "include": [
       {
         "duckdb_arch": "windows_amd64",
-        "vcpkg_target_triplet": "x64-windows-static-md-release",
-        "vcpkg_host_triplet": "x64-windows-static-md-release"
+        "vcpkg_target_triplet": "x64-windows-static-md-release-vs2019comp",
+        "vcpkg_host_triplet": "x64-windows-static-md-release-vs2019comp"
       },
       {
         "duckdb_arch": "windows_amd64_mingw",

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -89,6 +89,10 @@ ifneq ("${VCPKG_HOST_TRIPLET}", "")
 	TOOLCHAIN_FLAGS:=${TOOLCHAIN_FLAGS} -DVCPKG_HOST_TRIPLET='${VCPKG_HOST_TRIPLET}'
 endif
 
+ifeq ($(DUCKDB_PLATFORM),windows_amd64)
+	TOOLCHAIN_FLAGS:=${TOOLCHAIN_FLAGS} -DVCPKG_OVERLAY_TRIPLETS=${PROJ_DIR}extension-ci-tools/toolchains/
+endif
+
 #### Enable Ninja as generator
 ifeq ($(GEN),ninja)
 	GENERATOR=-G "Ninja" -DFORCE_COLORED_OUTPUT=1

--- a/toolchains/x64-windows-static-md-release-vs2019comp.cmake
+++ b/toolchains/x64-windows-static-md-release-vs2019comp.cmake
@@ -1,0 +1,11 @@
+# It is necessary to pass this flag to AWS C++ SDK to enable compatibility with VS2019 C++ stdlib
+set(VCPKG_CXX_FLAGS "/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")
+# If VCPKG_CXX_FLAGS is set, VCPKG_C_FLAGS must be set
+set(VCPKG_C_FLAGS "")
+
+# The following is copied from x64-windows-static-md-release.cmake
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_BUILD_TYPE release)


### PR DESCRIPTION
This change adds a new VCPKG triplet `x64-windows-static-md-release-vs2019comp` (and a toolchain definition
for it) that is intended to be used for all MSVC Windows builds (currently only `x64-windows-static-md-release`). ([reference](https://github.com/MicrosoftDocs/vcpkg-docs/blob/2b78788399105087b0488a309d565f9a033870d6/vcpkg/users/buildsystems/cmake-integration.md#vcpkg_overlay_triplets)).

This custom triplet appeared to bes necessary necessary to pass `/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` flag to AWS C++ SDK compilation. This flag enables the compatibility with older C++ stdlib from VS2019. It was added to the `duckdb/duckdb` repo in duckdb/duckdb#17991. That addition effectively propagated this flag to the extensions sources, but not to extension dependencies built with VCPKG. The problem with `duckdb-aws` was uncovered while running tests added in duckdb/duckdb#18149 PR.

edit: changed a chainloaded toolchain to the custom triplet