### PR TITLE
Allow non-static build

### DIFF
--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -100,6 +100,9 @@ endif
 
 #### Configuration for this extension
 EXTENSION_FLAGS=-DDUCKDB_EXTENSION_CONFIGS='${EXT_CONFIG}'
+
+# This setting controls how DuckDB is linked into the loadable extensions. 
+# Setting this to 0 will speed up linking and reduce binary size, but may render your extension binaries unloadable on some platforms.
 EXTENSION_STATIC_BUILD ?= 1
 
 BUILD_FLAGS=-DEXTENSION_STATIC_BUILD=$(EXTENSION_STATIC_BUILD) $(EXTENSION_FLAGS) ${EXT_FLAGS} $(CORE_EXTENSION_VAR) $(OSX_BUILD_FLAG) $(RUST_FLAGS) $(TOOLCHAIN_FLAGS) -DDUCKDB_EXPLICIT_PLATFORM='${DUCKDB_PLATFORM}' -DCUSTOM_LINKER=${CUSTOM_LINKER} -DOVERRIDE_GIT_DESCRIBE="${OVERRIDE_GIT_DESCRIBE}" -DUNITTEST_ROOT_DIRECTORY="$(PROJ_DIR)" -DBENCHMARK_ROOT_DIRECTORY="$(PROJ_DIR)" -DENABLE_UNITTEST_CPP_TESTS=FALSE


### PR DESCRIPTION
Hi duckdb team, I found building extension slow, and most of the time is spent on linking.
Checking the extension-ci tools, I find we force to leverage static link and doesn't provide any way to tune.

Checking on some dummy extensions (the company I'm working is working on a duckdb extension product, but public yet), switch from `EXTENSION_STATIC_BUILD` from 1 to 0 seems to improve 40% of the overall link time.
I would like to know if the team has any concerns on this? Thank you!