### PR TITLE
fix: improve ccache options

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -457,6 +457,8 @@ jobs:
         with:
           key: extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
           save: ${{ inputs.save_cache }}
+          max-size: 1500M
+          append-timestamp: false
 
       - uses: actions/setup-python@v5
         with:
@@ -690,6 +692,9 @@ jobs:
         with:
           key: ${{ github.job }}-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
           save: ${{ inputs.save_cache }}
+          max-size: 1500M
+          append-timestamp: false
+
 
       - uses: r-lib/actions/setup-r@v2
         if:  matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw'
@@ -904,6 +909,9 @@ jobs:
         with:
           key: ${{ github.job }}-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
           save: ${{ inputs.save_cache }}
+          max-size: 1500M
+          append-timestamp: false
+
 
       - name: Downgrade AWS cli
         if: ${{ (contains(format(';{0};', inputs.extra_toolchains), ';downgraded_aws_cli;')) }}


### PR DESCRIPTION
Hi guys,

This PR increases the `ccache`'s max cache size (to 1.5gb rather than 500mb) and removes the timestamps from the cache entries. I believe this will improve the cache hit ratio rather than running up against GitHub limits for cache sizes.  

Rusty
