### PR TITLE
Add option to checkout duckdb to the version of the calling repo

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -108,7 +108,7 @@ on:
         required: false
         type: string
         default: ""
-      # Experimental option to allow automatically building the vcpkg dependengcies of duckdb extensions that are used for testing
+      # Experimental option to allow automatically building the vcpkg dependencies of duckdb extensions that are used for testing
       use_merged_vcpkg_manifest:
         required: false
         type: string
@@ -289,16 +289,16 @@ jobs:
         run: |
           DUCKDB_GIT_REPOSITORY=${{ inputs.override_duckdb_repository }} make set_duckdb_repository
 
-      - name: Checkout DuckDB to version
-        if: ${{inputs.duckdb_version != '' && !inputs.set_caller_as_duckdb}}
-        run: |
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
-
       - name: Set DuckDB to ref of calling workflow
         if: ${{inputs.set_caller_as_duckdb}}
         uses: actions/checkout@v4
         with:
           path: 'duckdb'
+
+      - name: Checkout DuckDB to version
+        if: ${{ inputs.duckdb_version != '' }}
+        run: |
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -524,16 +524,16 @@ jobs:
         run: |
           DUCKDB_GIT_REPOSITORY=${{ inputs.override_duckdb_repository }} make set_duckdb_repository
 
-      - name: Checkout DuckDB to version
-        if: ${{inputs.duckdb_version != '' && !inputs.set_caller_as_duckdb}}
-        run: |
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
-
       - name: Set DuckDB to ref of calling workflow
         if: ${{inputs.set_caller_as_duckdb}}
         uses: actions/checkout@v4
         with:
           path: 'duckdb'
+
+      - name: Checkout DuckDB to version
+        if: ${{ inputs.duckdb_version != '' }}
+        run: |
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -799,19 +799,18 @@ jobs:
         run: |
           make set_duckdb_repository
 
-      - name: Checkout DuckDB to version
-        if: ${{inputs.duckdb_version != '' && !inputs.set_caller_as_duckdb}}
-        env:
-          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
-        run: |
-          make set_duckdb_version
-
       - name: Set DuckDB to ref of calling workflow
         if: ${{inputs.set_caller_as_duckdb}}
         uses: actions/checkout@v4
         with:
           path: 'duckdb'
 
+      - name: Checkout DuckDB to version
+        if: ${{ inputs.duckdb_version != '' }}
+        env:
+          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
+          run: |
+            make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -971,16 +970,16 @@ jobs:
         run: |
           DUCKDB_GIT_REPOSITORY=${{ inputs.override_duckdb_repository }} make set_duckdb_repository
 
-      - name: Checkout DuckDB to version
-        if: ${{inputs.duckdb_version != '' && !inputs.set_caller_as_duckdb}}
-        run: |
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
-
       - name: Set DuckDB to ref of calling workflow
         if: ${{inputs.set_caller_as_duckdb}}
         uses: actions/checkout@v4
         with:
           path: 'duckdb'
+
+      - name: Checkout DuckDB to version
+        if: ${{ inputs.duckdb_version != '' }}
+        run: |
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -97,6 +97,7 @@ on:
         required: false
         type: string
         default: ""
+      # Internal tooling option: allows automatically fetching the duckdb repo and ref from the calling repository.
       set_caller_as_duckdb:
         required: false
         type: boolean

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -97,13 +97,17 @@ on:
         required: false
         type: string
         default: ""
+      set_caller_as_duckdb:
+        required: false
+        type: boolean
+        default: false
       # Pass extra toolchains
       #   available: (parser_tools, rust, fortran, omp, python3)
       extra_toolchains:
         required: false
         type: string
         default: ""
-      # Experimental option to allow automatically building the vcpkg dependencies of duckdb extensions that are used for testing
+      # Experimental option to allow automatically building the vcpkg dependengcies of duckdb extensions that are used for testing
       use_merged_vcpkg_manifest:
         required: false
         type: string
@@ -288,6 +292,12 @@ jobs:
         if: ${{inputs.duckdb_version != ''}}
         run: |
           DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
+
+      - name: Set DuckDB to ref of calling workflow
+        if: ${{inputs.set_caller_as_duckdb}}
+        uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -517,6 +527,12 @@ jobs:
         if: ${{inputs.duckdb_version != ''}}
         run: |
           DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
+
+      - name: Set DuckDB to ref of calling workflow
+        if: ${{inputs.set_caller_as_duckdb}}
+        uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
@@ -789,6 +805,13 @@ jobs:
         run: |
           make set_duckdb_version
 
+      - name: Set DuckDB to ref of calling workflow
+        if: ${{inputs.set_caller_as_duckdb}}
+        uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
+
+
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
         run: |
@@ -951,6 +974,12 @@ jobs:
         if: ${{inputs.duckdb_version != ''}}
         run: |
           DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
+
+      - name: Set DuckDB to ref of calling workflow
+        if: ${{inputs.set_caller_as_duckdb}}
+        uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -289,7 +289,7 @@ jobs:
           DUCKDB_GIT_REPOSITORY=${{ inputs.override_duckdb_repository }} make set_duckdb_repository
 
       - name: Checkout DuckDB to version
-        if: ${{inputs.duckdb_version != ''}}
+        if: ${{inputs.duckdb_version != '' && !inputs.set_caller_as_duckdb}}
         run: |
           DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
@@ -524,7 +524,7 @@ jobs:
           DUCKDB_GIT_REPOSITORY=${{ inputs.override_duckdb_repository }} make set_duckdb_repository
 
       - name: Checkout DuckDB to version
-        if: ${{inputs.duckdb_version != ''}}
+        if: ${{inputs.duckdb_version != '' && !inputs.set_caller_as_duckdb}}
         run: |
           DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
@@ -799,7 +799,7 @@ jobs:
           make set_duckdb_repository
 
       - name: Checkout DuckDB to version
-        if: ${{inputs.duckdb_version != ''}}
+        if: ${{inputs.duckdb_version != '' && !inputs.set_caller_as_duckdb}}
         env:
           DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
         run: |
@@ -971,7 +971,7 @@ jobs:
           DUCKDB_GIT_REPOSITORY=${{ inputs.override_duckdb_repository }} make set_duckdb_repository
 
       - name: Checkout DuckDB to version
-        if: ${{inputs.duckdb_version != ''}}
+        if: ${{inputs.duckdb_version != '' && !inputs.set_caller_as_duckdb}}
         run: |
           DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 


### PR DESCRIPTION
This dubious option is needed to run this workflow on DuckDB CI. I don't like it either but it seems to be the best way forward @carlopi 