### PR TITLE
fix: add libtool as a basic package

### DIFF
--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
 # Setup the basic necessities
-RUN yum install -y curl zip unzip tar autoconf
+RUN yum install -y curl zip unzip tar autoconf libtool
 RUN yum install -y ninja-build
 RUN yum install -y perl-IPC-Cmd
 RUN yum install -y ccache

--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3
 
 # Setup the basic necessities
 RUN apk update --y -qq
-RUN apk add -qq ccache cmake git ninja ninja-build clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers libunwind-dev jq
+RUN apk add -qq ccache cmake git ninja ninja-build clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers libunwind-dev jq libtool
 RUN wget https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/aws-cli-2.22.10-r0.apk
 RUN apk add --allow-untrusted aws-cli-2.22.10-r0.apk
 

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_aarch64
 
 # Setup the basic necessities
-RUN yum install -y curl zip unzip tar autoconf
+RUN yum install -y curl zip unzip tar autoconf libtool
 RUN yum install -y ninja-build
 RUN yum install -y perl-IPC-Cmd
 RUN yum install -y ccache


### PR DESCRIPTION
To facilitate some vcpkg packages, install `libtool` by default in Dockerfiles.

