### PR TITLE
Run tests using relative path instead of absolute path

### DIFF
--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -193,11 +193,11 @@ test_debug: $(TEST_DEBUG_TARGET)
 test_reldebug: $(TEST_RELDEBUG_TARGET)
 
 test_release_internal:
-	./build/release/$(TEST_PATH) "$(PROJ_DIR)test/*"
+	./build/release/$(TEST_PATH) "test/*"
 test_debug_internal:
-	./build/debug/$(TEST_PATH) "$(PROJ_DIR)test/*"
+	./build/debug/$(TEST_PATH) "test/*"
 test_reldebug_internal:
-	./build/reldebug/$(TEST_PATH) "$(PROJ_DIR)test/*"
+	./build/reldebug/$(TEST_PATH) "test/*"
 
 tests_skipped:
 	@echo "Tests are skipped in this run..."


### PR DESCRIPTION
With https://github.com/duckdb/extension-ci-tools/pull/156, tests are now loaded from the `test` dir in the extension directory automatically.

We still register the extension tests again using `LOAD_TESTS`. This is no longer really required - however - the extension template and most extensions still use `LOAD_TESTS`. This causes double registration of tests that can be annoying when developing and can also get in the way when running tests from other sources (e.g. when running main DuckDB tests using `--test-dir duckdb`).

In order to move towards removing the `LOAD_TESTS` we should move towards running the extension local tests.

Another advantage here is also that the test names that get printed in CI are cleaned up (i.e. moved towards relative paths, instead of always having the absolute paths).