### PR TITLE
Handle macOS cross-compilation:

### DIFF
--- a/makefiles/c_api_extensions/rust.Makefile
+++ b/makefiles/c_api_extensions/rust.Makefile
@@ -24,6 +24,14 @@ ifneq ($(DUCKDB_WASM_PLATFORM),)
 	TARGET_INFO=--target $(TARGET) --example $(EXTENSION_NAME)
 	IS_EXAMPLE=/examples
 	TARGET_PATH=./target/$(TARGET)
+else ifeq ($(OSX_BUILD_ARCH),x86_64)
+  TARGET=x86_64-apple-darwin
+  TARGET_INFO=--target $(TARGET)
+  TARGET_PATH=./target/$(TARGET)
+else ifeq ($(OSX_BUILD_ARCH),arm64)
+  TARGET=aarch64-apple-darwin
+  TARGET_INFO=--target $(TARGET)
+  TARGET_PATH=./target/$(TARGET)
 else
 	IS_EXAMPLE=
 	TARGET_PATH=./target


### PR DESCRIPTION
* Fix #158: host tripplet is wrong on x86-osx
* Fix (refs duckdb/extension-template-rs#28): [macOS Intel] Community extension rusty_quack fails to load due to "wrong architecture"