### PR TITLE
install curl for windows builds

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -767,6 +767,10 @@ jobs:
         run: |
           choco install jq -y
 
+      - name: Install curl
+        run: |
+          choco install curl -y
+
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
         continue-on-error: true


### PR DESCRIPTION
Have been seen some build errors when bumping submodule pointers. Looks like curl is not installed?

https://github.com/Tmonster/duckdb-aws/actions/runs/17488754870/job/49673558809