### PR TITLE
Add reduced ci mode

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -29,6 +29,7 @@ jobs:
       extra_extension_config: |
         duckdb_extension_load(json)
         duckdb_extension_load(tpch)
+      reduced_ci_mode: true # TODO remove
     secrets: inherit
 
   extension-template-capi:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -157,6 +157,11 @@ on:
         required: false
         type: string
         default: ""
+      # Enable for a standard, minimum set of archs to get decent test coverage
+      reduced_ci_mode:
+        required: false
+        type: boolean
+        default: false
 
 env:
   VCPKG_BINARY_SOURCES: ${{inputs.vcpkg_binary_sources == '' && 'clear;http,https://vcpkg-cache.duckdb.org,read' || inputs.vcpkg_binary_sources }}
@@ -181,10 +186,10 @@ jobs:
       - id: parse-matrices
         run: |
           mkdir build
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode ' || ''}}"
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode ' || ''}}"
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode ' || ''}}"
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode ' || ''}}"
 
       - id: set-matrix-linux
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -464,7 +464,9 @@ jobs:
   macos:
     name: MacOS
     runs-on: macos-latest
-    needs: generate_matrix
+    needs:
+      - generate_matrix
+      - linux
     if: ${{ needs.generate_matrix.outputs.osx_matrix != '{}' && needs.generate_matrix.outputs.osx_matrix != '' }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.osx_matrix)}}
@@ -685,7 +687,9 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
-    needs: generate_matrix
+    needs:
+      - generate_matrix
+      - linux
     if: ${{ needs.generate_matrix.outputs.windows_matrix != '{}' && needs.generate_matrix.outputs.windows_matrix != '' }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.windows_matrix)}}
@@ -933,7 +937,9 @@ jobs:
   wasm:
     name: DuckDB-Wasm
     runs-on: ubuntu-latest
-    needs: generate_matrix
+    needs:
+      - generate_matrix
+      - linux
     if: ${{ needs.generate_matrix.outputs.wasm_matrix != '{}' && needs.generate_matrix.outputs.wasm_matrix != '' }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.wasm_matrix)}}

--- a/config/distribution_matrix.json
+++ b/config/distribution_matrix.json
@@ -5,19 +5,22 @@
         "duckdb_arch": "linux_amd64",
         "runner": "ubuntu-24.04",
         "vcpkg_target_triplet": "x64-linux-release",
-        "vcpkg_host_triplet": "x64-linux-release"
+        "vcpkg_host_triplet": "x64-linux-release",
+        "run_in_reduced_ci_mode": true
       },
       {
         "duckdb_arch": "linux_arm64",
         "runner": "ubuntu-24.04-arm",
         "vcpkg_target_triplet": "arm64-linux-release",
-        "vcpkg_host_triplet": "arm64-linux-release"
+        "vcpkg_host_triplet": "arm64-linux-release",
+        "run_in_reduced_ci_mode": false
       },
       {
         "duckdb_arch": "linux_amd64_musl",
         "runner": "ubuntu-24.04",
         "vcpkg_target_triplet": "x64-linux-release",
-        "vcpkg_host_triplet": "x64-linux-release"
+        "vcpkg_host_triplet": "x64-linux-release",
+        "run_in_reduced_ci_mode": false
       }
     ]
   },
@@ -27,13 +30,15 @@
         "duckdb_arch": "osx_amd64",
         "osx_build_arch": "x86_64",
         "vcpkg_target_triplet": "x64-osx-release",
-        "vcpkg_host_triplet": "arm64-osx-release"
+        "vcpkg_host_triplet": "arm64-osx-release",
+        "run_in_reduced_ci_mode": false
       },
       {
         "duckdb_arch": "osx_arm64",
         "osx_build_arch": "arm64",
         "vcpkg_target_triplet": "arm64-osx-release",
-        "vcpkg_host_triplet": "arm64-osx-release"
+        "vcpkg_host_triplet": "arm64-osx-release",
+        "run_in_reduced_ci_mode": true
       }
     ]
   },
@@ -42,12 +47,14 @@
       {
         "duckdb_arch": "windows_amd64",
         "vcpkg_target_triplet": "x64-windows-static-md-release-vs2019comp",
-        "vcpkg_host_triplet": "x64-windows-static-md-release-vs2019comp"
+        "vcpkg_host_triplet": "x64-windows-static-md-release-vs2019comp",
+        "run_in_reduced_ci_mode": true
       },
       {
         "duckdb_arch": "windows_amd64_mingw",
         "vcpkg_target_triplet": "x64-mingw-static",
-        "vcpkg_host_triplet": "x64-mingw-static"
+        "vcpkg_host_triplet": "x64-mingw-static",
+        "run_in_reduced_ci_mode": true
       }
     ]
   },
@@ -56,17 +63,20 @@
       {
         "duckdb_arch": "wasm_mvp",
         "vcpkg_target_triplet": "wasm32-emscripten",
-        "vcpkg_host_triplet": "x64-linux"
+        "vcpkg_host_triplet": "x64-linux",
+        "run_in_reduced_ci_mode": true
       },
       {
         "duckdb_arch": "wasm_eh",
         "vcpkg_target_triplet": "wasm32-emscripten",
-        "vcpkg_host_triplet": "x64-linux"
+        "vcpkg_host_triplet": "x64-linux",
+        "run_in_reduced_ci_mode": false
       },
       {
         "duckdb_arch": "wasm_threads",
         "vcpkg_target_triplet": "wasm32-emscripten",
-        "vcpkg_host_triplet": "x64-linux"
+        "vcpkg_host_triplet": "x64-linux",
+        "run_in_reduced_ci_mode": false
       }
     ]
   }

--- a/scripts/modify_distribution_matrix.py
+++ b/scripts/modify_distribution_matrix.py
@@ -11,26 +11,31 @@ parser.add_argument("--input", required=True, help="Input JSON file path")
 parser.add_argument("--exclude", required=True, help="Semicolon-separated list of excluded duckdb_arch values")
 parser.add_argument("--output", help="Output JSON file path")
 parser.add_argument("--pretty", action="store_true", help="Pretty print the output JSON")
+parser.add_argument("--reduced_ci_mode", action="store_true", help="Only produce builds that should run in reduced CI mode")
 parser.add_argument("--select_os", help="Select an OS to include in the output JSON")
 parser.add_argument("--deploy_matrix", action="store_true", help="Create a merged list used in deploy step")
 args = parser.parse_args()
+
 
 # Parse the input file path, excluded arch values, and output file path
 input_json_file_path = args.input
 excluded_arch_values = args.exclude.split(";")
 output_json_file_path = args.output
 select_os = args.select_os
+reduced_ci_mode = args.reduced_ci_mode
 
 # Read the input JSON file
 with open(input_json_file_path, "r") as json_file:
     data = json.load(json_file)
 
+def should_run(config, reduced_ci_mode):
+    return not reduced_ci_mode or config["run_in_reduced_ci_mode"]
 
 # Function to filter entries based on duckdb_arch values
 def filter_entries(data, arch_values):
     for os, config in data.items():
         if "include" in config:
-            config["include"] = [entry for entry in config["include"] if entry["duckdb_arch"] not in arch_values]
+            config["include"] = [entry for entry in config["include"] if (entry["duckdb_arch"] not in arch_values and should_run(entry, reduced_ci_mode))]
         if not config["include"]:
             del config["include"]
 


### PR DESCRIPTION
This PR aims to optimize CI usage by extensions.

It adds 2 main things:
- Makes builds partially sequential: first build linux, and then build the rest
- Add a `reduced_ci_mode` option which skips over half the builds while maintaining decent test coverage

When enabling `reduced_ci_mode` you now only run a single linux job `linux_amd64` first. Only after that passes the rest is run.

This seems sane to apply to all core extension repositories to avoid unnecessary CI time on failing PR pushes.

For community extensions, we probably don't want reduced_ci_mode, but at least it will only run the linux builds now initially. We could improve this further by only running the `linux_amd64` build, but that will make the workflow yaml file very ugly i think.
