### PR TITLE
Improve extension CI load

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -93,5 +93,5 @@ jobs:
       extra_toolchains: 'rust'
       save_cache: ${{ github.event_name != 'pull_request' }}
       vcpkg_binary_sources: ${{ github.event_name == 'push' && vars.VCPKG_BINARY_SOURCES || '' }}
-      reduced_ci_mode: true
+      reduced_ci_mode: enabled
     secrets: inherit

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  extension-template-main:
-    name: Extension template
-    uses: ./.github/workflows/_extension_distribution.yml
+  code-quality:
+    name: Code Quality
+    uses: ./.github/workflows/_extension_code_quality.yml
     with:
       extension_name: quack
       override_repository: duckdb/extension-template
@@ -22,15 +22,7 @@ jobs:
       duckdb_version: v1.3.2
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
-      extra_toolchains: 'parser_tools;fortran;omp;go;python3;downgraded_aws_cli;'
-      save_cache: ${{ github.event_name != 'pull_request' }}
-      vcpkg_binary_sources: ${{ github.event_name == 'push' && vars.VCPKG_BINARY_SOURCES || '' }}
-      upload_all_extensions: true
-      extra_extension_config: |
-        duckdb_extension_load(json)
-        duckdb_extension_load(tpch)
-      reduced_ci_mode: true # TODO remove
-    secrets: inherit
+      extra_toolchains: 'python3'
 
   extension-template-capi:
     name: Extension template (C API)
@@ -45,9 +37,34 @@ jobs:
       extra_toolchains: 'python3'
       save_cache: ${{ github.event_name != 'pull_request' }}
 
+  extension-template-main:
+    name: Extension template
+    uses: ./.github/workflows/_extension_distribution.yml
+    needs:
+      - extension-template-capi
+      - code-quality
+    with:
+      extension_name: quack
+      override_repository: duckdb/extension-template
+      override_ref: main
+      duckdb_version: v1.3.2
+      override_ci_tools_repository: ${{ github.repository }}
+      ci_tools_version: ${{ github.sha }}
+      extra_toolchains: 'parser_tools;fortran;omp;go;python3;downgraded_aws_cli;'
+      save_cache: ${{ github.event_name != 'pull_request' }}
+      vcpkg_binary_sources: ${{ github.event_name == 'push' && vars.VCPKG_BINARY_SOURCES || '' }}
+      upload_all_extensions: true
+      extra_extension_config: |
+        duckdb_extension_load(json)
+        duckdb_extension_load(tpch)
+    secrets: inherit
+
   extension-template-rust:
     name: Extension template (Rust)
     uses: ./.github/workflows/_extension_distribution.yml
+    needs:
+      - extension-template-capi
+      - code-quality
     with:
       extension_name: rusty_quack
       override_repository: duckdb/extension-template-rs
@@ -62,6 +79,9 @@ jobs:
   delta-extension-main:
     name: Rust builds (using Delta extension)
     uses: ./.github/workflows/_extension_distribution.yml
+    needs:
+      - extension-template-capi
+      - code-quality
     with:
       extension_name: delta
       override_repository: duckdb/duckdb_delta
@@ -73,16 +93,5 @@ jobs:
       extra_toolchains: 'rust'
       save_cache: ${{ github.event_name != 'pull_request' }}
       vcpkg_binary_sources: ${{ github.event_name == 'push' && vars.VCPKG_BINARY_SOURCES || '' }}
+      reduced_ci_mode: true
     secrets: inherit
-
-  code-quality:
-    name: Code Quality
-    uses: ./.github/workflows/_extension_code_quality.yml
-    with:
-      extension_name: quack
-      override_repository: duckdb/extension-template
-      override_ref: main
-      duckdb_version: v1.3.2
-      override_ci_tools_repository: ${{ github.repository }}
-      ci_tools_version: ${{ github.sha }}
-      extra_toolchains: 'python3'

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -29,6 +29,7 @@ jobs:
       extra_extension_config: |
         duckdb_extension_load(json)
         duckdb_extension_load(tpch)
+      reduced_ci_mode: true # TODO remove
     secrets: inherit
 
   extension-template-capi:

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -58,6 +58,11 @@ on:
         required: false
         type: string
         default: "./extension-ci-tools/scripts/modify_distribution_matrix.py"
+      # matches the reduced_ci_mode in .github/workflows/_extension_distribution.yml. Ensures the deploy step is still tested with correct archs
+      reduced_ci_mode:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   generate_matrix:
@@ -75,7 +80,7 @@ jobs:
 
       - id: parse-matrices
         run: |
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}"
           deploy_matrix="`cat deploy_matrix.json`"
           echo deploy_matrix=$deploy_matrix >> $GITHUB_OUTPUT
           echo `cat $GITHUB_OUTPUT`

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -58,11 +58,11 @@ on:
         required: false
         type: string
         default: "./extension-ci-tools/scripts/modify_distribution_matrix.py"
-      # matches the reduced_ci_mode in .github/workflows/_extension_distribution.yml. Ensures the deploy step is still tested with correct archs
+      # auto/enabled/disabled: when enabled (or enabled through auto) will skip redundant architectures to reduce CI load
       reduced_ci_mode:
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'auto'
 
 jobs:
   generate_matrix:
@@ -80,7 +80,7 @@ jobs:
 
       - id: parse-matrices
         run: |
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}"
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
           deploy_matrix="`cat deploy_matrix.json`"
           echo deploy_matrix=$deploy_matrix >> $GITHUB_OUTPUT
           echo `cat $GITHUB_OUTPUT`

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -157,6 +157,11 @@ on:
         required: false
         type: string
         default: ""
+      # Enable for a standard, minimum set of archs to get decent test coverage
+      reduced_ci_mode:
+        required: false
+        type: boolean
+        default: false
 
 env:
   VCPKG_BINARY_SOURCES: ${{inputs.vcpkg_binary_sources == '' && 'clear;http,https://vcpkg-cache.duckdb.org,read' || inputs.vcpkg_binary_sources }}
@@ -181,10 +186,10 @@ jobs:
       - id: parse-matrices
         run: |
           mkdir build
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode ' || ''}}"
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode ' || ''}}"
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode ' || ''}}"
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode ' || ''}}"
 
       - id: set-matrix-linux
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -254,7 +254,6 @@ jobs:
       - name: Restart docker to run on /mnt
         run: |
           sudo systemctl stop docker
-          exit 1
 
       - name: Configure Docker with custom data directory
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -186,10 +186,10 @@ jobs:
       - id: parse-matrices
         run: |
           mkdir build
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode ' || ''}}"
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode ' || ''}}"
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode ' || ''}}"
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode ' || ''}}"
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}"
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}"
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}"
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}"
 
       - id: set-matrix-linux
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -186,10 +186,10 @@ jobs:
       - id: parse-matrices
         run: |
           mkdir build
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}"
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}"
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}"
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty "${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}"
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty ${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty ${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty ${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty ${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}
 
       - id: set-matrix-linux
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -470,6 +470,7 @@ jobs:
       - linux
     if: |
       always() &&
+      !cancelled() &&
       needs.generate_matrix.outputs.osx_matrix != '{}' &&
       needs.generate_matrix.outputs.osx_matrix != '' &&
       needs.generate_matrix.result == 'success' &&
@@ -698,6 +699,7 @@ jobs:
       - linux
     if: |
       always() &&
+      !cancelled() &&
       needs.generate_matrix.outputs.windows_matrix != '{}' &&
       needs.generate_matrix.outputs.windows_matrix != '' &&
       needs.generate_matrix.result == 'success' &&
@@ -953,6 +955,7 @@ jobs:
       - linux
     if: |
       always() &&
+      !cancelled() &&
       needs.generate_matrix.outputs.wasm_matrix != '{}' &&
       needs.generate_matrix.outputs.wasm_matrix != '' &&
       needs.generate_matrix.result == 'success' &&

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -157,11 +157,11 @@ on:
         required: false
         type: string
         default: ""
-      # Enable for a standard, minimum set of archs to get decent test coverage
+      # auto/enabled/disabled: when enabled (
       reduced_ci_mode:
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'auto'
 
 env:
   VCPKG_BINARY_SOURCES: ${{inputs.vcpkg_binary_sources == '' && 'clear;http,https://vcpkg-cache.duckdb.org,read' || inputs.vcpkg_binary_sources }}
@@ -186,10 +186,10 @@ jobs:
       - id: parse-matrices
         run: |
           mkdir build
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty ${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty ${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty ${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty ${{ inputs.reduced_ci_mode && '--reduced_ci_mode' || ''}}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
 
       - id: set-matrix-linux
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -254,6 +254,7 @@ jobs:
       - name: Restart docker to run on /mnt
         run: |
           sudo systemctl stop docker
+          exit 1
 
       - name: Configure Docker with custom data directory
         run: |

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -464,7 +464,9 @@ jobs:
   macos:
     name: MacOS
     runs-on: macos-latest
-    needs: generate_matrix
+    needs:
+      - generate_matrix
+      - linux
     if: ${{ needs.generate_matrix.outputs.osx_matrix != '{}' && needs.generate_matrix.outputs.osx_matrix != '' }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.osx_matrix)}}
@@ -685,7 +687,9 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
-    needs: generate_matrix
+    needs:
+      - generate_matrix
+      - linux
     if: ${{ needs.generate_matrix.outputs.windows_matrix != '{}' && needs.generate_matrix.outputs.windows_matrix != '' }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.windows_matrix)}}
@@ -933,7 +937,9 @@ jobs:
   wasm:
     name: DuckDB-Wasm
     runs-on: ubuntu-latest
-    needs: generate_matrix
+    needs:
+      - generate_matrix
+      - linux
     if: ${{ needs.generate_matrix.outputs.wasm_matrix != '{}' && needs.generate_matrix.outputs.wasm_matrix != '' }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.wasm_matrix)}}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -467,7 +467,12 @@ jobs:
     needs:
       - generate_matrix
       - linux
-    if: ${{ needs.generate_matrix.outputs.osx_matrix != '{}' && needs.generate_matrix.outputs.osx_matrix != '' }}
+    if: |
+      always() &&
+      needs.generate_matrix.outputs.osx_matrix != '{}' &&
+      needs.generate_matrix.outputs.osx_matrix != '' &&
+      needs.generate_matrix.result == 'success' &&
+      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.osx_matrix)}}
     env:
@@ -690,7 +695,12 @@ jobs:
     needs:
       - generate_matrix
       - linux
-    if: ${{ needs.generate_matrix.outputs.windows_matrix != '{}' && needs.generate_matrix.outputs.windows_matrix != '' }}
+    if: |
+      always() &&
+      needs.generate_matrix.outputs.windows_matrix != '{}' &&
+      needs.generate_matrix.outputs.windows_matrix != '' &&
+      needs.generate_matrix.result == 'success' &&
+      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.windows_matrix)}}
     env:
@@ -940,7 +950,12 @@ jobs:
     needs:
       - generate_matrix
       - linux
-    if: ${{ needs.generate_matrix.outputs.wasm_matrix != '{}' && needs.generate_matrix.outputs.wasm_matrix != '' }}
+    if: |
+      always() &&
+      needs.generate_matrix.outputs.wasm_matrix != '{}' &&
+      needs.generate_matrix.outputs.wasm_matrix != '' &&
+      needs.generate_matrix.result == 'success' &&
+      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.wasm_matrix)}}
     env:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -157,7 +157,7 @@ on:
         required: false
         type: string
         default: ""
-      # auto/enabled/disabled: when enabled (
+      # auto/enabled/disabled: when enabled (or enabled through auto) will skip redundant architectures to reduce CI load
       reduced_ci_mode:
         required: false
         type: string

--- a/config/distribution_matrix.json
+++ b/config/distribution_matrix.json
@@ -5,19 +5,22 @@
         "duckdb_arch": "linux_amd64",
         "runner": "ubuntu-24.04",
         "vcpkg_target_triplet": "x64-linux-release",
-        "vcpkg_host_triplet": "x64-linux-release"
+        "vcpkg_host_triplet": "x64-linux-release",
+        "run_in_reduced_ci_mode": true
       },
       {
         "duckdb_arch": "linux_arm64",
         "runner": "ubuntu-24.04-arm",
         "vcpkg_target_triplet": "arm64-linux-release",
-        "vcpkg_host_triplet": "arm64-linux-release"
+        "vcpkg_host_triplet": "arm64-linux-release",
+        "run_in_reduced_ci_mode": false
       },
       {
         "duckdb_arch": "linux_amd64_musl",
         "runner": "ubuntu-24.04",
         "vcpkg_target_triplet": "x64-linux-release",
-        "vcpkg_host_triplet": "x64-linux-release"
+        "vcpkg_host_triplet": "x64-linux-release",
+        "run_in_reduced_ci_mode": false
       }
     ]
   },
@@ -27,13 +30,15 @@
         "duckdb_arch": "osx_amd64",
         "osx_build_arch": "x86_64",
         "vcpkg_target_triplet": "x64-osx-release",
-        "vcpkg_host_triplet": "arm64-osx-release"
+        "vcpkg_host_triplet": "arm64-osx-release",
+        "run_in_reduced_ci_mode": false
       },
       {
         "duckdb_arch": "osx_arm64",
         "osx_build_arch": "arm64",
         "vcpkg_target_triplet": "arm64-osx-release",
-        "vcpkg_host_triplet": "arm64-osx-release"
+        "vcpkg_host_triplet": "arm64-osx-release",
+        "run_in_reduced_ci_mode": true
       }
     ]
   },
@@ -42,12 +47,14 @@
       {
         "duckdb_arch": "windows_amd64",
         "vcpkg_target_triplet": "x64-windows-static-md-release-vs2019comp",
-        "vcpkg_host_triplet": "x64-windows-static-md-release-vs2019comp"
+        "vcpkg_host_triplet": "x64-windows-static-md-release-vs2019comp",
+        "run_in_reduced_ci_mode": true
       },
       {
         "duckdb_arch": "windows_amd64_mingw",
         "vcpkg_target_triplet": "x64-mingw-static",
-        "vcpkg_host_triplet": "x64-mingw-static"
+        "vcpkg_host_triplet": "x64-mingw-static",
+        "run_in_reduced_ci_mode": true
       }
     ]
   },
@@ -56,17 +63,20 @@
       {
         "duckdb_arch": "wasm_mvp",
         "vcpkg_target_triplet": "wasm32-emscripten",
-        "vcpkg_host_triplet": "x64-linux"
+        "vcpkg_host_triplet": "x64-linux",
+        "run_in_reduced_ci_mode": true
       },
       {
         "duckdb_arch": "wasm_eh",
         "vcpkg_target_triplet": "wasm32-emscripten",
-        "vcpkg_host_triplet": "x64-linux"
+        "vcpkg_host_triplet": "x64-linux",
+        "run_in_reduced_ci_mode": false
       },
       {
         "duckdb_arch": "wasm_threads",
         "vcpkg_target_triplet": "wasm32-emscripten",
-        "vcpkg_host_triplet": "x64-linux"
+        "vcpkg_host_triplet": "x64-linux",
+        "run_in_reduced_ci_mode": false
       }
     ]
   }

--- a/scripts/modify_distribution_matrix.py
+++ b/scripts/modify_distribution_matrix.py
@@ -11,7 +11,7 @@ parser.add_argument("--input", required=True, help="Input JSON file path")
 parser.add_argument("--exclude", required=True, help="Semicolon-separated list of excluded duckdb_arch values")
 parser.add_argument("--output", help="Output JSON file path")
 parser.add_argument("--pretty", action="store_true", help="Pretty print the output JSON")
-parser.add_argument("--reduced_ci_mode", action="store_true", help="Only produce builds that should run in reduced CI mode")
+parser.add_argument("--reduced_ci_mode", required=True, help="Set to default/enabled/disabled, when enabled, filters out redundant archs for testing")
 parser.add_argument("--select_os", help="Select an OS to include in the output JSON")
 parser.add_argument("--deploy_matrix", action="store_true", help="Create a merged list used in deploy step")
 args = parser.parse_args()
@@ -23,6 +23,19 @@ excluded_arch_values = args.exclude.split(";")
 output_json_file_path = args.output
 select_os = args.select_os
 reduced_ci_mode = args.reduced_ci_mode
+
+# Parse reduced CI mode
+if reduced_ci_mode == "auto":
+    # Note auto is off for now TODO: change?
+    reduced_ci_mode = False
+elif reduced_ci_mode == "enabled":
+    reduced_ci_mode = True
+elif reduced_ci_mode == "disabled":
+    reduced_ci_mode = False
+elif reduced_ci_mode is None:
+    raise Exception("Unknown reduced_ci_mode value: None - must be default/enabled/disabled.")
+else:
+    raise Exception("Unknown reduced_ci_mode value: " + reduced_ci_mode + " - must be default/enabled/disabled.")
 
 # Read the input JSON file
 with open(input_json_file_path, "r") as json_file:

--- a/scripts/modify_distribution_matrix.py
+++ b/scripts/modify_distribution_matrix.py
@@ -11,26 +11,31 @@ parser.add_argument("--input", required=True, help="Input JSON file path")
 parser.add_argument("--exclude", required=True, help="Semicolon-separated list of excluded duckdb_arch values")
 parser.add_argument("--output", help="Output JSON file path")
 parser.add_argument("--pretty", action="store_true", help="Pretty print the output JSON")
+parser.add_argument("--reduced_ci_mode", action="store_true", help="Only produce builds that should run in reduced CI mode")
 parser.add_argument("--select_os", help="Select an OS to include in the output JSON")
 parser.add_argument("--deploy_matrix", action="store_true", help="Create a merged list used in deploy step")
 args = parser.parse_args()
+
 
 # Parse the input file path, excluded arch values, and output file path
 input_json_file_path = args.input
 excluded_arch_values = args.exclude.split(";")
 output_json_file_path = args.output
 select_os = args.select_os
+reduced_ci_mode = args.reduced_ci_mode
 
 # Read the input JSON file
 with open(input_json_file_path, "r") as json_file:
     data = json.load(json_file)
 
+def should_run(config, reduced_ci_mode):
+    return not reduced_ci_mode or config["run_in_reduced_ci_mode"]
 
 # Function to filter entries based on duckdb_arch values
 def filter_entries(data, arch_values):
     for os, config in data.items():
         if "include" in config:
-            config["include"] = [entry for entry in config["include"] if entry["duckdb_arch"] not in arch_values]
+            config["include"] = [entry for entry in config["include"] if (entry["duckdb_arch"] not in arch_values and should_run(entry, reduced_ci_mode))]
         if not config["include"]:
             del config["include"]
 


### PR DESCRIPTION
This PR makes several improvements to CI load.

- In `.github/workflows/_extension_distribution.yml`: run linux first, then the rest (fail early)
- Add `reduced_ci_mode` settings which removes redundant architectures (to be used in Core Extension PRs)
   - added option to rust job in `.github/workflows/TestCITools.yml` to test it
- Reorders the ci in `.github/workflows/TestCITools.yml` to try to make it fail on a cheap job if things are wrong reducing CI load of this repository itself

This allows to have PRs with `reduced_ci_mode` in core extensions be very efficient, since they run, sequentially:
1.  Build `linux_amd64`
2. Build `osx_arm64`, `windows_amd64`, `windows_amd64_mingw`, `wasm_eh`

Then after merging the full thing is run


## Followups
- We could consider to not run OSX at all in PRs
- Not run CI on core extension merges but only periodically building nightlies