### PR TITLE
fix: add mingw rust target on windows builds

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -769,6 +769,12 @@ jobs:
         if: (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;'))
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup Rust for Mingw
+        if: (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-gnu
+
       - name: 'Setup go'
         if: ${{ (inputs.enable_go || contains(format(';{0};', inputs.extra_toolchains), ';go;'))}}
         uses: actions/setup-go@v4


### PR DESCRIPTION
When building on the Windows `mingw` the `x86_64-pc-windows-gnu` Rust toolchain is no longer available, this change installs it when it is necessary.

It seems this tool chain was previously installed in the Github Action runner, but is no longer.