### PR TITLE
fix: bump emscripten version to allow Rust extensions to build

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -1030,7 +1030,7 @@ jobs:
 
       - uses: mymindstorm/setup-emsdk@v13
         with:
-          version: 3.1.71
+          version: 4.0.14
 
       - name: Setup Rust for cross compilation
         if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;'))}}


### PR DESCRIPTION
When building Rust extensions they are starting to specify `emscripten` command line options to `emcc` that aren't supported by the version of `emscripten` that was installed by `extension-ci-tools`.  

An example error is here:

```
Unknown option '--enable-bulk-memory-opt'
emcc: error: '/home/runner/work/_temp/4837560f-6804-4033-9fe2-65175cee57e6/emsdk-main/upstream/bin/wasm-opt --strip-target-features --post-emscripten --pass-arg=post-emscripten-side-module -O3 --low-memory-unused --pass-arg=directize-initial-contents-immutable --no-stack-ir /home/runner/work/lindel/lindel/build/wasm_eh/extension/lindel/lindel.duckdb_extension.wasm -o /home/runner/work/lindel/lindel/build/wasm_eh/extension/lindel/lindel.duckdb_extension.wasm --mvp-features --enable-bulk-memory --enable-bulk-memory-opt --enable-call-indirect-overlong --enable-exception-handling --enable-multivalue --enable-mutable-globals --enable-nontrapping-float-to-int --enable-reference-types --enable-sign-ext' failed (returned 1)
make[3]: *** [extension/lindel/CMakeFiles/lindel_loadable_extension.dir/build.make:120: extension/lindel/lindel.duckdb_extension] Error 1
```

This PR upgrades `emscripten` to a recent release compared to the release from 2024-11-07.

By using this newer version of emscripten I am able to release the `lindel` extension and likely others for 1.4.0 using WASM.

Here is an unsuccessful build:

https://github.com/Query-farm/lindel/actions/runs/18039196768

Here is a successful build:

https://github.com/Query-farm/lindel/actions/runs/18040021226/job/51336703727
