### PR TITLE
Add dependency between build and metadata targets

### DIFF
--- a/makefiles/c_api_extensions/base.Makefile
+++ b/makefiles/c_api_extensions/base.Makefile
@@ -221,7 +221,7 @@ ifeq ($(USE_UNSTABLE_C_API),1)
 	UNSTABLE_C_API_FLAG+=--abi-type C_STRUCT_UNSTABLE
 endif
 
-build_extension_with_metadata_debug: check_configure link_wasm_debug
+build_extension_with_metadata_debug: check_configure link_wasm_debug build_extension_library_debug
 	$(PYTHON_VENV_BIN) extension-ci-tools/scripts/append_extension_metadata.py \
 			-l $(EXTENSION_BUILD_PATH)/debug/$(EXTENSION_FILENAME_NO_METADATA) \
 			-o $(EXTENSION_BUILD_PATH)/debug/$(EXTENSION_FILENAME) \
@@ -231,7 +231,7 @@ build_extension_with_metadata_debug: check_configure link_wasm_debug
 			-pf configure/platform.txt $(UNSTABLE_C_API_FLAG)
 	$(PYTHON_VENV_BIN) -c "import shutil;shutil.copyfile('$(EXTENSION_BUILD_PATH)/debug/$(EXTENSION_FILENAME)', '$(EXTENSION_BUILD_PATH)/debug/extension/$(EXTENSION_NAME)/$(EXTENSION_FILENAME)')"
 
-build_extension_with_metadata_release: check_configure link_wasm_release
+build_extension_with_metadata_release: check_configure link_wasm_release build_extension_library_release
 	$(PYTHON_VENV_BIN) extension-ci-tools/scripts/append_extension_metadata.py \
 			-l $(EXTENSION_BUILD_PATH)/release/$(EXTENSION_FILENAME_NO_METADATA) \
 			-o $(EXTENSION_BUILD_PATH)/release/$(EXTENSION_FILENAME) \


### PR DESCRIPTION
It seems that with C API extension setup, the `build_extension_with_metadata_debug` target does not have a dependency on the target that actually builds the library. So if the `make` is for some reason invoked in parallel mode with `-j` option then the metadata target fails like this:

```python
Traceback (most recent call last):
  File "/path/to/extension-ci-tools/scripts/append_extension_metadata.py", line 121, in <module>
    main()
    ~~~~^^
  File "/path/to/extension-ci-tools/scripts/append_extension_metadata.py", line 57, in main
    shutil.copyfile(args.library_file, OUTPUT_FILE_TMP)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/shutil.py", line 260, in copyfile
    with open(src, 'rb') as fsrc:
         ~~~~^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: './build/release/libmy_ext.so'
```

Perhaps this is not a realistic scenario, because, to actually enable parallel builds the top-level `make` should to be invoked without `-j` like one of the following variants:

```
GEN=ninja make
```
```
CMAKE_BUILD_PARALLEL_LEVEL=<num_cpus> make
```

Still, assuming the `build_extension_library_debug` target exists for all toolchains (currently, C/C++ and Rust) that may use the `build_extension_with_metadata_debug` then it may be better to add an explicit dependency on it.

The same is also applied to metadata and build `_release` targets.