### PR TITLE
fix: pin WASM Rust version for compatibility with `emscripten`

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -1060,7 +1060,7 @@ jobs:
 
       - name: Setup Rust for cross compilation
         if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;'))}}
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.86.0
         with:
           targets: wasm32-unknown-emscripten
 


### PR DESCRIPTION
Hi DuckDB Team,

I tracked down the build failures I was seeing with my Rust-based extensions for WASM. The issue turned out to be that we were always installing the latest version of Rust - but newer versions (anything after 1.86.0) pass options that aren’t recognized by the fixed version of `emscripten` currently in use.

I came across a similar issue reported here:

https://github.com/PyO3/maturin/issues/2549

This PR pins the Rust version for WASM builds to 1.86.0, which is fully compatible with the current `emscripten` setup. Once this is merged, I’ll be able to release the Rust-based extensions for the WASM targets.

Thanks for reviewing this.

Best,
Rusty
