### PR TITLE
fix: For linux builds increase ccache max size to 1gb, disable compression

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -375,6 +375,8 @@ jobs:
           EXTENSION_NAME=${{ inputs.extension_name }}
           EXTENSION_CANONICAL=${{ inputs.extension_canonical }}
           LINUX_CI_IN_DOCKER=1
+          CCACHE_MAXSIZE=1G
+          CCACHE_NOCOMPRESS=1
           EOF
           echo '${{ inputs.test_config }}'| jq -r '.test_env_variables // {} | to_entries | map("\(.key)=\(.value)")|.[]' >> docker_env.txt
 


### PR DESCRIPTION
Hi DuckDB Team,

While working on some other improvements to `extension-ci-tools`, I noticed that the Linux build cache is approaching the 400 MB limit. This PR increases the `ccache` max size to 1 GB and disables internal compression, since the cache is already compressed using `zstandard` during the save step at the end of the build - no need to compress it twice.

Please review and merge when convenient.

Best,
Rusty