### PR TITLE
Pin duckdb-sqllogictest-python to known good version

### DIFF
--- a/makefiles/c_api_extensions/base.Makefile
+++ b/makefiles/c_api_extensions/base.Makefile
@@ -252,7 +252,7 @@ venv: configure/venv
 configure/venv:
 	$(PYTHON_BIN) -m venv configure/venv
 	$(PYTHON_VENV_BIN) -m pip install $(DUCKDB_PIP_INSTALL)
-	$(PYTHON_VENV_BIN) -m pip install git+https://github.com/duckdb/duckdb-sqllogictest-python
+	$(PYTHON_VENV_BIN) -m pip install git+https://github.com/duckdb/duckdb-sqllogictest-python@2ac8dbc012ddbd96a57dca37784fd8ee3c0eb021
 	$(PYTHON_VENV_BIN) -m pip install packaging
 
 #############################################


### PR DESCRIPTION
See https://github.com/duckdb/duckdb-sqllogictest-python/pull/12#discussion_r2451871647

Proof that the commit works:

```
❯ uv run --python=3.13 --with git+https://github.com/duckdb/duckdb-sqllogictest-python@2ac8dbc012ddbd96a57dca37784fd8ee3c0eb021 --with duckdb -m duckdb_sqllogictest --help
usage: __main__.py [-h] [--file-path FILE_PATH] [--test-dir TEST_DIR] [--external-extension EXTERNAL_EXTENSION] [--preinstall-extensions PREINSTALL_EXTENSIONS] [--file-list FILE_LIST]
                   [--start-offset START_OFFSET] [--build-dir BUILD_DIR]

Execute SQL logic tests.

options:
  -h, --help            show this help message and exit
  --file-path FILE_PATH
                        Path to the test file
  --test-dir TEST_DIR   Path to the test directory holding the test files
  --external-extension EXTERNAL_EXTENSION
                        Path to an extra extension file to test
  --preinstall-extensions PREINSTALL_EXTENSIONS
                        Comma-separated list of extensions to preinstall during testing
  --file-list FILE_LIST
                        Path to the file containing a list of tests to run
  --start-offset, -s START_OFFSET
                        Start offset for the tests
  --build-dir BUILD_DIR
                        Path to the build directory, used for loading extensions
```