### PR TITLE
Add unixodbc toolchain

### DIFF
--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -98,3 +98,9 @@ RUN case "$extra_toolchains" in \
   ;; \
 esac
 
+# Install unixODBC
+RUN case "$extra_toolchains" in \
+  *\;unixodbc\;*) \
+    yum install -y unixODBC-devel \
+  ;; \
+esac

--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -91,3 +91,10 @@ RUN case "$extra_toolchains" in \
     apk add -qq python3 \
   ;; \
 esac
+
+# Install unixODBC
+RUN case "$extra_toolchains" in \
+  *\;unixodbc\;*) \
+    apk add -qq unixodbc-dev \
+  ;; \
+esac

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -100,3 +100,9 @@ RUN case "$extra_toolchains" in \
   ;; \
 esac
 
+# Install unixODBC
+RUN case "$extra_toolchains" in \
+  *\;unixodbc\;*) \
+    yum install -y unixODBC-devel \
+  ;; \
+esac


### PR DESCRIPTION
This PR adds support for installing `unixODBC-devel` package as an additional "toolchain" for Docker builds.