### PR TITLE
Add unixodbc toolchain support on macOS

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -659,6 +659,11 @@ jobs:
           echo "CPPFLAGS=-I/opt/homebrew/opt/libomp/include" >> $GITHUB_ENV
           echo "CXXFLAGS=-I/opt/homebrew/opt/libomp/include" >> $GITHUB_ENV
 
+      - name: Install unixODBC
+        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';unixodbc;')}}
+        run: |
+          brew install unixodbc
+
       - name: Override AWS CLI
         if: ${{ (contains(format(';{0};', inputs.extra_toolchains), ';downgraded_aws_cli;')) }}
         shell: bash


### PR DESCRIPTION
This PR adds support for installing `unixodbc` package as an additional "toolchain" on macOS image.