### PR TITLE
Support deploying without duckdb submodule

### DIFF
--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -101,6 +101,9 @@ jobs:
 
       - name: Checkout DuckDB to version
         run: |
+          if [ ! -d duckdb ]; then
+            git clone https://github.com/duckdb/duckdb.git
+          fi
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
 


### PR DESCRIPTION
The logic in `_extension_deploy.yml` assumes that the `duckdb` submodule exists in the extension repo. It needs `duckdb` repo to be checked out to use `deploy_script` (`extension-upload-single.sh`) and to get the actual Git version (when `duckdb_version` does not point to a tag).

It is possible to make `duckdb` checkout optional by copying the upload script into the extension repo (or to this one) and by adding the `duckdb_git_revision` parameter. But, as majority of extensions are going to have `duckdb` submodule anyway, it seems to be easier to check whether the submodule exists and clone the repo otherwise.

Testing: checked in a fork that the patched logic works correctly (up to the upload script invocation).