### PR TITLE
Add opt_in_archs to _extension_deploy workflow

### DIFF
--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: ""
+      # ';' separated list of architectures to opt into, for example: 'windows_arm64;linux_arm64_musl'
+      opt_in_archs:
+        required: false
+        type: string
+        default: ""
       # Whether to upload this deployment as the latest. This may overwrite a previous deployment.
       deploy_latest:
         required: false
@@ -80,7 +85,7 @@ jobs:
 
       - id: parse-matrices
         run: |
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --opt_in "${{ inputs.opt_in_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
           deploy_matrix="`cat deploy_matrix.json`"
           echo deploy_matrix=$deploy_matrix >> $GITHUB_OUTPUT
           echo `cat $GITHUB_OUTPUT`


### PR DESCRIPTION
This is a follow-up to #268, apparently `opt_in` arches list needs to be specified for `_extension_deploy` workflow too to enable for them the uploading to S3.