### PR TITLE
Fix: Remove invalid --y flag from apk update command

### DIFF
--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3
 ###
 
 # Setup the basic necessities
-RUN apk update --y -qq
+RUN apk update -q
 RUN apk add -qq ccache cmake git ninja ninja-build clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers libunwind-dev jq libtool
 RUN wget https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/aws-cli-2.22.10-r0.apk
 RUN apk add --allow-untrusted aws-cli-2.22.10-r0.apk


### PR DESCRIPTION
Alpine 3.23 released today (Dec 3, 2025) broke compatibility via apk-tools v3, which now strictly validates flags and rejects invalid ones.

The --y flag is only valid for 'apk add', not 'apk update'. This change:
- Removes the invalid --y flag from apk update
- Changes -qq to -q (correct quiet flag for apk update)
- Fixes Docker build failures in CI

Fixes: Docker build error 'ERROR: command line: unrecognized option y'