### PR TITLE
Update extension makefiles to support the latest sqllogictest.

### DIFF
--- a/makefiles/c_api_extensions/base.Makefile
+++ b/makefiles/c_api_extensions/base.Makefile
@@ -109,11 +109,11 @@ configure/extension_version.txt:
 #############################################
 
 # Note: to override the default test runner, create a symlink to a different venv
-TEST_RUNNER=$(PYTHON_VENV_BIN) -m duckdb_sqllogictest
+TEST_RUNNER=$(PYTHON_VENV_BIN) -m sqllogic.test_sqllogic
 
-TEST_RUNNER_BASE=$(TEST_RUNNER) --test-dir test/sql $(EXTRA_EXTENSIONS_PARAM)
-TEST_RUNNER_DEBUG=$(TEST_RUNNER_BASE) --external-extension build/debug/$(EXTENSION_NAME).duckdb_extension
-TEST_RUNNER_RELEASE=$(TEST_RUNNER_BASE) --external-extension build/release/$(EXTENSION_NAME).duckdb_extension
+TEST_RUNNER_BASE=$(TEST_RUNNER) --duckdb-root-dir . --test-dir test/sql $(EXTRA_EXTENSIONS_PARAM)
+TEST_RUNNER_DEBUG=$(TEST_RUNNER_BASE) --build-dir ${EXTENSION_BUILD_PATH}/debug
+TEST_RUNNER_RELEASE=$(TEST_RUNNER_BASE) --build-dir ${EXTENSION_BUILD_PATH}/release
 
 # By default latest duckdb is installed, set DUCKDB_TEST_VERSION to switch to a different version
 DUCKDB_PIP_INSTALL?=duckdb
@@ -128,6 +128,9 @@ endif
 ifeq ($(DUCKDB_GIT_VERSION),main)
 	DUCKDB_PIP_INSTALL=--pre duckdb
 endif
+
+# Allow overriding the sqllogictest version in the event of incompatible changes
+DUCKDB_SQLLOGICTEST_VERSION?=main
 
 TEST_RELEASE_TARGET=test_extension_release_internal
 TEST_DEBUG_TARGET=test_extension_debug_internal
@@ -254,7 +257,9 @@ venv: configure/venv
 configure/venv:
 	$(PYTHON_BIN) -m venv configure/venv
 	$(PYTHON_VENV_BIN) -m pip install $(DUCKDB_PIP_INSTALL)
-	$(PYTHON_VENV_BIN) -m pip install git+https://github.com/duckdb/duckdb-sqllogictest-python@2ac8dbc012ddbd96a57dca37784fd8ee3c0eb021
+	# Restore install from the real repo once https://github.com/duckdb/duckdb-sqllogictest-python/pull/15 is merged
+	# $(PYTHON_VENV_BIN) -m pip install git+https://github.com/duckdb/duckdb-sqllogictest-python@${DUCKDB_SQLLOGICTEST_VERSION}
+	$(PYTHON_VENV_BIN) -m pip install git+https://github.com/troycurtisjr/duckdb-sqllogictest-python@update-testing-for-inet
 	$(PYTHON_VENV_BIN) -m pip install packaging
 
 #############################################


### PR DESCRIPTION
While getting the tests working for the `inet` extension, I noticed that the `c_api_extensions` makefiles was doing an unconstrained install of https://github.com/duckdb/duckdb-sqllogictest-python, and with [a recentish update](https://github.com/duckdb/duckdb-sqllogictest-python/pull/12) the calling method in these makefiles is broken. I do see that the version was later pinned in this repo, though that hasn't been updated in the `inet` extension yet, but in this MR I've updated things to use the latest sqllogictest.

This PR does two things:

* Adds in support for optionally locking to a "version" of duckdb-sqllogictest, which will be either a branch or hash, with a way for extensions to override it
* Update the makefile to use the new calling conventions

Note this currently this PR points to my outstanding branch for duckdb-sqllogictest, awaiting the merge of [my PR there](https://github.com/duckdb/duckdb-sqllogictest-python/pull/15). I do think that PR is required here for two reasons:

* There is an undeclared pytest dependency now in duckdb-sqllogictest, needed to actually use the new calling conventions
* There is a bug in handling `require <extension>` that doesn't work with out-of-tree extensions correctly

I've created this PR now for comments about the overall approach, and to understand if there is any additional testing to be done in this repo.  I've currently tested my changes within the `inet` extension, but it isn't clear to me how to best to further test the update.

