### PR TITLE
Option to override vcpkg triplets

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -39,6 +39,7 @@ jobs:
       # mingw arch below is not opt-in, included to check that it is allowed in the list
       opt_in_archs: 'windows_arm64;windows_amd64_mingw;'
       save_cache: ${{ github.event_name != 'pull_request' }}
+      vcpkg_triplets_override: 'windows_arm64:arm64-windows-static-md-release-vs2019comp;'
 
   extension-template-main:
     name: Extension template

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -72,6 +72,11 @@ on:
         required: false
         type: string
         default: ''
+      # format: 'arch_name1:triplet1;arch_name2:triplet2'
+      vcpkg_triplets_override:
+        required: false
+        type: string
+        default: ''
       # Override the default script producing the matrices. Allows specifying custom matrices.
       matrix_parse_script:
         required: false
@@ -200,10 +205,42 @@ jobs:
       - id: parse-matrices
         run: |
           mkdir build
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux   --output build/linux_matrix.json   --exclude "${{ inputs.exclude_archs }}" --opt_in "${{ inputs.opt_in_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx     --output build/osx_matrix.json     --exclude "${{ inputs.exclude_archs }}" --opt_in "${{ inputs.opt_in_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --opt_in "${{ inputs.opt_in_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm    --output build/wasm_matrix.json    --exclude "${{ inputs.exclude_archs }}" --opt_in "${{ inputs.opt_in_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
+          python3 ${{ inputs.matrix_parse_script }}                    \
+            --input extension-ci-tools/config/distribution_matrix.json \
+            --select_os linux                                          \
+            --output build/linux_matrix.json                           \
+            --exclude "${{ inputs.exclude_archs }}"                    \
+            --opt_in "${{ inputs.opt_in_archs }}"                      \
+            --pretty                                                   \
+            --reduced_ci_mode ${{ inputs.reduced_ci_mode }}            \
+            --vcpkg_triplets_override "${{ inputs.vcpkg_triplets_override }}"
+          python3 ${{ inputs.matrix_parse_script }}                    \
+            --input extension-ci-tools/config/distribution_matrix.json \
+            --select_os osx                                            \
+            --output build/osx_matrix.json                             \
+            --exclude "${{ inputs.exclude_archs }}"                    \
+            --opt_in "${{ inputs.opt_in_archs }}"                      \
+            --pretty                                                   \
+            --reduced_ci_mode ${{ inputs.reduced_ci_mode }}            \
+            --vcpkg_triplets_override "${{ inputs.vcpkg_triplets_override }}"
+          python3 ${{ inputs.matrix_parse_script }}                    \
+            --input extension-ci-tools/config/distribution_matrix.json \
+            --select_os windows                                        \
+            --output build/windows_matrix.json                         \
+            --exclude "${{ inputs.exclude_archs }}"                    \
+            --opt_in "${{ inputs.opt_in_archs }}"                      \
+            --pretty                                                   \
+            --reduced_ci_mode ${{ inputs.reduced_ci_mode }}            \
+            --vcpkg_triplets_override "${{ inputs.vcpkg_triplets_override }}"
+          python3 ${{ inputs.matrix_parse_script }}                    \
+            --input extension-ci-tools/config/distribution_matrix.json \
+            --select_os wasm                                           \
+            --output build/wasm_matrix.json                            \
+            --exclude "${{ inputs.exclude_archs }}"                    \
+            --opt_in "${{ inputs.opt_in_archs }}"                      \
+            --pretty                                                   \
+            --reduced_ci_mode ${{ inputs.reduced_ci_mode }}            \
+            --vcpkg_triplets_override "${{ inputs.vcpkg_triplets_override }}"
 
       - id: set-matrix-linux
         run: |

--- a/makefiles/c_api_extensions/base.Makefile
+++ b/makefiles/c_api_extensions/base.Makefile
@@ -39,6 +39,13 @@ ifeq ($(DUCKDB_PLATFORM),windows_amd64_mingw)
 	EXTENSION_LIB_FILENAME=lib$(EXTENSION_NAME).dll
 endif
 
+# Propagate toolchains
+ifeq ($(DUCKDB_PLATFORM),windows_amd64)
+       TOOLCHAIN_FLAGS:=${TOOLCHAIN_FLAGS} -DVCPKG_OVERLAY_TRIPLETS=${PROJ_DIR}extension-ci-tools/toolchains/
+else ifeq ($(DUCKDB_PLATFORM),windows_arm64)
+       TOOLCHAIN_FLAGS:=${TOOLCHAIN_FLAGS} -DVCPKG_OVERLAY_TRIPLETS=${PROJ_DIR}extension-ci-tools/toolchains/
+endif
+
 #############################################
 ### Main extension parameters
 #############################################

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -97,6 +97,12 @@ ifneq ("${VCPKG_HOST_TRIPLET}", "")
 	TOOLCHAIN_FLAGS:=${TOOLCHAIN_FLAGS} -DVCPKG_HOST_TRIPLET='${VCPKG_HOST_TRIPLET}'
 endif
 
+ifeq ($(DUCKDB_PLATFORM),windows_amd64)
+	TOOLCHAIN_FLAGS:=${TOOLCHAIN_FLAGS} -DVCPKG_OVERLAY_TRIPLETS=${PROJ_DIR}extension-ci-tools/toolchains/
+else ifeq ($(DUCKDB_PLATFORM),windows_arm64)
+	TOOLCHAIN_FLAGS:=${TOOLCHAIN_FLAGS} -DVCPKG_OVERLAY_TRIPLETS=${PROJ_DIR}extension-ci-tools/toolchains/
+endif
+
 #### Enable Ninja as generator
 ifeq ($(GEN),ninja)
 	GENERATOR=-G "Ninja" -DFORCE_COLORED_OUTPUT=1

--- a/toolchains/arm64-windows-static-md-release-vs2019comp.cmake
+++ b/toolchains/arm64-windows-static-md-release-vs2019comp.cmake
@@ -1,0 +1,11 @@
+# It is necessary to pass this flag to AWS C++ SDK to enable compatibility with VS2019 C++ stdlib
+set(VCPKG_CXX_FLAGS "/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")
+# If VCPKG_CXX_FLAGS is set, VCPKG_C_FLAGS must be set
+set(VCPKG_C_FLAGS "")
+
+# The following is copied from arm64-windows-static-md-release.cmake
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_BUILD_TYPE release)

--- a/toolchains/x64-windows-static-md-release-vs2019comp.cmake
+++ b/toolchains/x64-windows-static-md-release-vs2019comp.cmake
@@ -1,0 +1,11 @@
+# It is necessary to pass this flag to AWS C++ SDK to enable compatibility with VS2019 C++ stdlib
+set(VCPKG_CXX_FLAGS "/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")
+# If VCPKG_CXX_FLAGS is set, VCPKG_C_FLAGS must be set
+set(VCPKG_C_FLAGS "")
+
+# The following is copied from x64-windows-static-md-release.cmake
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_BUILD_TYPE release)


### PR DESCRIPTION
This PR adds an option `vcpkg_triplets_override` to the `_extension_distribution.yml` that can be used to override vcpkg triplets specified in the `distribution_matrix.json`.

Example:

```yaml
uses: ./.github/workflows/_extension_distribution.yml
    with:
      ...
      vcpkg_triplets_override: 'windows_amd64:x64-windows-static-md-release-vs2019comp;windows_arm64:arm64-windows-static-md-release-vs2019comp;'
```

It also restores the custom triplets removed in #276 so they can be requested by caller workflows.

Testing: added example usage of the new option to `TestCITools.yml`