### PR TITLE
Add conditional for [skip ci] to workflows

### DIFF
--- a/.github/workflows/_extension_client_tests.yml
+++ b/.github/workflows/_extension_client_tests.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   python:
     name: Python
+    if: (github.event_name != 'push' || !contains(join(github.event.commits.*.message, ' '), '[SKIP_CI]')) && (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[SKIP_CI]'))
     runs-on: ubuntu-latest
     env:
       GEN: ninja

--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -48,7 +48,7 @@ env:
 jobs:
   format-check:
     name: Format Check
-    if: contains(inputs.format_checks, 'format')
+    if: contains(inputs.format_checks, 'format') || (github.event_name != 'push' || !contains(join(github.event.commits.*.message, ' '), '[SKIP_CI]')) && (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[SKIP_CI]'))
     runs-on: ubuntu-22.04
 
     env:

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -72,6 +72,7 @@ on:
 jobs:
   generate_matrix:
     name: Generate matrix
+    if: (github.event_name != 'push' || !contains(join(github.event.commits.*.message, ' '), '[SKIP_CI]')) && (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[SKIP_CI]'))
     runs-on: ubuntu-latest
     outputs:
       deploy_matrix: ${{ steps.parse-matrices.outputs.deploy_matrix }}
@@ -94,7 +95,7 @@ jobs:
     name: Deploy to nightly
     runs-on: ubuntu-latest
     needs: generate_matrix
-    if: ${{ needs.generate_matrix.outputs.deploy_matrix != '{}' && needs.generate_matrix.outputs.deploy_matrix != '' }}
+    if: ${{ (needs.generate_matrix.outputs.deploy_matrix != '{}' && needs.generate_matrix.outputs.deploy_matrix != '') || ((github.event_name != 'push' || !contains(join(github.event.commits.*.message, ' '), '[SKIP_CI]')) && (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[SKIP_CI]'))) }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.deploy_matrix)}}
 

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -183,6 +183,7 @@ env:
 jobs:
   generate_matrix:
     name: Generate matrix
+    if: (github.event_name != 'push' || !contains(join(github.event.commits.*.message, ' '), '[SKIP_CI]')) && (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[SKIP_CI]'))
     runs-on: ubuntu-latest
     outputs:
       linux_matrix: ${{ steps.set-matrix-linux.outputs.linux_matrix }}
@@ -233,7 +234,7 @@ jobs:
     name: Linux
     runs-on: ${{ matrix.runner }}
     needs: generate_matrix
-    if: ${{ needs.generate_matrix.outputs.linux_matrix != '{}' && needs.generate_matrix.outputs.linux_matrix != '' }}
+    if: ${{ (needs.generate_matrix.outputs.linux_matrix != '{}' && needs.generate_matrix.outputs.linux_matrix != '') || ((github.event_name != 'push' || !contains(join(github.event.commits.*.message, ' '), '[SKIP_CI]')) && (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[SKIP_CI]'))) }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.linux_matrix)}}
     env:
@@ -503,12 +504,14 @@ jobs:
       - generate_matrix
       - linux
     if: |
-      always() &&
+      (always() &&
       !cancelled() &&
       needs.generate_matrix.outputs.osx_matrix != '{}' &&
       needs.generate_matrix.outputs.osx_matrix != '' &&
       needs.generate_matrix.result == 'success' &&
-      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
+      (needs.linux.result == 'success' || needs.linux.result == 'skipped')) ||
+      ((github.event_name != 'push' || !contains(join(github.event.commits.*.message, ' '), '[SKIP_CI]')) && 
+      (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[SKIP_CI]')))
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.osx_matrix)}}
     env:
@@ -741,12 +744,14 @@ jobs:
       - generate_matrix
       - linux
     if: |
-      always() &&
+      (always() &&
       !cancelled() &&
       needs.generate_matrix.outputs.windows_matrix != '{}' &&
       needs.generate_matrix.outputs.windows_matrix != '' &&
       needs.generate_matrix.result == 'success' &&
-      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
+      (needs.linux.result == 'success' || needs.linux.result == 'skipped')) ||
+      ((github.event_name != 'push' || !contains(join(github.event.commits.*.message, ' '), '[SKIP_CI]')) &&
+      (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[SKIP_CI]')))
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.windows_matrix)}}
     env:
@@ -1011,12 +1016,14 @@ jobs:
       - generate_matrix
       - linux
     if: |
-      always() &&
+      (always() &&
       !cancelled() &&
       needs.generate_matrix.outputs.wasm_matrix != '{}' &&
       needs.generate_matrix.outputs.wasm_matrix != '' &&
       needs.generate_matrix.result == 'success' &&
-      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
+      (needs.linux.result == 'success' || needs.linux.result == 'skipped')) ||
+      (github.event_name != 'push' || !contains(join(github.event.commits.*.message, ' '), '[SKIP_CI]')) && 
+      (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[SKIP_CI]'))
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.wasm_matrix)}}
     env:


### PR DESCRIPTION
This PR adds a conditional skip to the CI workflow to avoid running builds and tests when the commit message or PR title contains the explicit pattern: `[skip ci]`.