### PR TITLE
force yum to rebuild repo package cache

### DIFF
--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -1,5 +1,8 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
+RUN yum --verbose clean all
+RUN yum --verbose makecache
+
 # Setup the basic necessities
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y curl zip unzip tar autoconf libtool

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -1,5 +1,8 @@
 FROM quay.io/pypa/manylinux_2_28_aarch64
 
+RUN yum --verbose clean all
+RUN yum --verbose makecache
+
 # Setup the basic necessities
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y curl zip unzip tar autoconf libtool


### PR DESCRIPTION
force yum to rebuild repo package cache

Be extra paranoid, useful after almalinux got out of sync, and better policy since we're using dynamic package mgmt here.
(see also: https://forums.almalinux.org/t/404-errors-for-yum-dnf-installs-on-almalinux-8-aarch64/6992 )
