### PR TITLE
Fix tidy-check when VCPKG is used

### DIFF
--- a/.github/workflows/_extension_code_quality.yml
+++ b/.github/workflows/_extension_code_quality.yml
@@ -31,6 +31,21 @@ on:
         type: string
         required: false
         default: "format;tidy"
+      # Override the default vcpkg repository
+      vcpkg_url:
+        required: false
+        type: string
+        default: "https://github.com/microsoft/vcpkg.git"
+      # Override the default vcpkg commit used by this version of DuckDB
+      vcpkg_commit:
+        required: false
+        type: string
+        default: "ce613c41372b23b1f51333815feb3edd87ef8a8b"
+      # Experimental option to allow automatically building the vcpkg dependencies of duckdb extensions that are used for testing
+      use_merged_vcpkg_manifest:
+        required: false
+        type: string
+        default: ""
     secrets:
       GH_TOKEN:
         required: false
@@ -136,6 +151,23 @@ jobs:
         shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-tidy && sudo pip3 install pybind11[global] --break-system-packages
 
+      - name: Setup vcpkg
+        shell: bash
+        run: |
+          mkdir local_vcpkg_installation
+          cmake --version
+          cd local_vcpkg_installation
+          git init
+          git remote add origin ${{ inputs.vcpkg_url }}
+          git fetch origin ${{ inputs.vcpkg_commit }}
+          git checkout ${{ inputs.vcpkg_commit }}
+          ./bootstrap-vcpkg.sh
+          echo "VCPKG_ROOT=${{ github.workspace }}/local_vcpkg_installation" >> $GITHUB_ENV
+          echo "VCPKG_TOOLCHAIN_PATH=${{ github.workspace }}/local_vcpkg_installation/scripts/buildsystems/vcpkg.cmake" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/local_vcpkg_installation" >> $GITHUB_PATH
+
       - name: Tidy Check Diff
         shell: bash
+        env:
+          USE_MERGED_VCPKG_MANIFEST: ${{ inputs.use_merged_vcpkg_manifest }}
         run: make tidy-check

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -264,9 +264,9 @@ format-fix:
 format-main:
 	python3 duckdb/scripts/format.py main --fix --noconfirm --directories src test
 
-tidy-check:
+tidy-check: ${EXTENSION_CONFIG_STEP}
 	mkdir -p ./build/tidy
-	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_DEBUG_FLAGS) -DDISABLE_UNITY=1 -DCLANG_TIDY=1 -S $(DUCKDB_SRCDIR) -B build/tidy
+	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_DEBUG_FLAGS) $(VCPKG_MANIFEST_FLAGS) -DDISABLE_UNITY=1 -DCLANG_TIDY=1 -S $(DUCKDB_SRCDIR) -B build/tidy
 	cp duckdb/.clang-tidy build/tidy/.clang-tidy
 	cd build/tidy && python3 ../../duckdb/scripts/run-clang-tidy.py '$(PROJ_DIR)src/.*/' -header-filter '$(PROJ_DIR)src/.*/' -quiet ${TIDY_THREAD_PARAMETER} ${TIDY_BINARY_PARAMETER} ${TIDY_PERFORM_CHECKS}
 


### PR DESCRIPTION
## Problem
Hey team!

The tidy-check job's extension build can fail because the required dependencies are not retrieved by VCPKG. This problem is described by #223.

## Changes
I've copied the `Setup vcpkg` step from the `_extension_distribution.yml` workflow into the `_extension_code_quality.yml` workflow. Thus, VCPKG is now installed prior to the extension build. 

Furthermore, I've updated the `tidy-check` Makefile target to include VCPKG in the build process. For that I've taken inspiration from the Makefile's [debug target](https://github.com/Noorts/extension-ci-tools/blob/fix-tidy-check-vcpkg/makefiles/duckdb_extension.Makefile#L155-L158).

## Result
Using these changes my tidy-check now successfully builds the extension (including its dependencies).

Before: https://github.com/Noorts/PDXearch/actions/runs/21448678175/job/61771370390

```
# Before
CMake Warning at CMakeLists.txt:1341 (message):
  Extension 'pdxearch' has a vcpkg.json, but build was not run with VCPKG.
  If build fails, check out VCPKG build instructions in
  'duckdb/extension/README.md' or try manually installing the dependencies in
  /home/runner/work/PDXearch/PDXearch/vcpkg.json


-- Found OpenMP_C: -fopenmp (found version "4.5")
-- Found OpenMP_CXX: -fopenmp (found version "4.5")
-- Found OpenMP: TRUE (found version "4.5")
CMake Error at /home/runner/work/PDXearch/PDXearch/CMakeLists.txt:23 (find_package):
  By not providing "FindEigen3.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Eigen3", but
  CMake did not find one.
```

After: https://github.com/Noorts/PDXearch/actions/runs/21448728200/job/61771541738.

## Remaining Concerns
I've included `USE_MERGED_VCPKG_MANIFEST`, but I'm not familiar with the feature and haven't tested it. It would be nice to confirm that the approach is correct, or to change it as necessary.