### PR TITLE
Use newer version of ninja on Alpine

### DIFF
--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -12,6 +12,9 @@ RUN apk add --allow-untrusted aws-cli-2.22.10-r0.apk
 RUN wget https://dl-cdn.alpinelinux.org/alpine/v3.23/community/x86_64/ninja-build-1.13.2-r0.apk
 RUN apk add --allow-untrusted ninja-build-1.13.2-r0.apk
 
+# Add ninja to path
+ENV PATH="/usr/lib/ninja-build/bin:${PATH}"
+
 # Setup VCPKG n a mounted volume TODO: figure out how to cache this
 ARG vcpkg_url
 ARG vcpkg_commit
@@ -25,9 +28,6 @@ RUN mkdir /vcpkg && \
 ENV VCPKG_ROOT=/vcpkg
 ENV VCPKG_TOOLCHAIN_PATH=/vcpkg/scripts/buildsystems/vcpkg.cmake
 ENV PATH="${VCPKG_ROOT}:${PATH}"
-
-# Add ninja to path
-ENV PATH="/usr/lib/ninja-build/bin:${PATH}"
 
 # Common environment variables
 ENV GEN=ninja


### PR DESCRIPTION
`pkgconf` dependency build (required by `gdal` from Spatial deps) fails on Alpine with the following:

```
Installing 36/48 pkgconf:x64-linux@2.5.1#4...
Building pkgconf:x64-linux@2.5.1#4...
-- Found Python version '3.12.12 at /usr/bin/python3'
-- Using meson: /vcpkg/downloads/tools/meson-1.9.0-d1fcc2/meson.py
Downloading https://github.com/pkgconf/pkgconf/archive/pkgconf-2.5.1.tar.gz -> pkgconf-pkgconf-pkgconf-2.5.1.tar.gz
Successfully downloaded pkgconf-pkgconf-pkgconf-2.5.1.tar.gz
-- Extracting source /vcpkg/downloads/pkgconf-pkgconf-pkgconf-2.5.1.tar.gz
-- Applying patch 001-unveil-fixes.patch
-- Using source at /vcpkg/buildtrees/pkgconf/src/conf-2.5.1-5bc6f0da3f.clean
-- Found ninja('1.12.1') but at least version 1.13.1 is required! Trying to use internal version if possible!
Downloading https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-linux.zip -> ninja-linux-1.13.1.zip
Successfully downloaded ninja-linux-1.13.1.zip
-- Configuring x64-linux-dbg
-- Getting CMake variables for x64-linux
CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:127 (message):
    Command failed: /vcpkg/downloads/tools/ninja/1.13.1-linux/ninja -v
    Working Directory: /vcpkg/buildtrees/pkgconf/x64-linux-rel/vcpkg-parallel-configure
    Error code: no such file or directory
```

`vcpkg` here downloads a prebuilt version of `ninja` that is not runnable on Alpine.

Currently we install both `samurai` and `ninja-1.12.1`, the proposed change is to only install `ninja-1.13.2` from newer version of Alpine.

Ref: duckdblabs/duckdb-internal#7293