### PR TITLE
Add multimedia extra_toolchain for FFmpeg and SDL2 support

### DIFF
--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -1,8 +1,5 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
-RUN yum --verbose clean all
-RUN yum --verbose makecache
-
 # Setup the basic necessities
 RUN yum install -y curl zip unzip tar autoconf libtool
 RUN yum install -y ninja-build
@@ -105,5 +102,15 @@ esac
 RUN case "$extra_toolchains" in \
   *\;unixodbc\;*) \
     yum install -y unixODBC-devel \
+  ;; \
+esac
+
+# Install multimedia libraries (FFmpeg, SDL2) for audio/video extensions
+# Requires EPEL and RPM Fusion repositories
+RUN case "$extra_toolchains" in \
+  *\;multimedia\;*) \
+    yum install -y epel-release && \
+    yum install -y --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm && \
+    yum install -y nasm SDL2-devel ffmpeg-devel \
   ;; \
 esac

--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -98,3 +98,10 @@ RUN case "$extra_toolchains" in \
     apk add -qq unixodbc-dev \
   ;; \
 esac
+
+# Install multimedia libraries (FFmpeg, SDL2) for audio/video extensions
+RUN case "$extra_toolchains" in \
+  *\;multimedia\;*) \
+    apk add -qq nasm sdl2-dev ffmpeg-dev \
+  ;; \
+esac

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -1,8 +1,5 @@
 FROM quay.io/pypa/manylinux_2_28_aarch64
 
-RUN yum --verbose clean all
-RUN yum --verbose makecache
-
 # Setup the basic necessities
 RUN yum install -y curl zip unzip tar autoconf libtool
 RUN yum install -y ninja-build
@@ -107,5 +104,15 @@ esac
 RUN case "$extra_toolchains" in \
   *\;unixodbc\;*) \
     yum install -y unixODBC-devel \
+  ;; \
+esac
+
+# Install multimedia libraries (FFmpeg, SDL2) for audio/video extensions
+# Requires EPEL and RPM Fusion repositories
+RUN case "$extra_toolchains" in \
+  *\;multimedia\;*) \
+    yum install -y epel-release && \
+    yum install -y --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm && \
+    yum install -y nasm SDL2-devel ffmpeg-devel \
   ;; \
 esac


### PR DESCRIPTION
Add a new `multimedia` option to extra_toolchains that installs:
- nasm (assembly compiler for optimized codecs)
- SDL2-devel/sdl2-dev (audio recording support)
- ffmpeg-devel/ffmpeg-dev (audio/video processing)

This enables DuckDB extensions that need audio/video processing capabilities (e.g., speech-to-text, media analysis) to build on Linux.

For RHEL-based images (linux_amd64, linux_arm64), this adds EPEL and RPM Fusion repositories to provide the required packages.

Also removes unnecessary yum cache rebuild commands from RHEL-based Dockerfiles and fixes override_ref in TestCITools.yml.

Usage in CI workflow:
  extra_toolchains: 'multimedia'