### PR TITLE
Add vcpkg.Makefile, that export 'setup-vcpkg' and 'cleanup-vcpkg'

### DIFF
--- a/makefiles/vcpkg.Makefile
+++ b/makefiles/vcpkg.Makefile
@@ -1,0 +1,10 @@
+#### Setup VCPKG to correct version 2025.12.12 tag is 84bab45d415d22042bd0b9081aea57f362da3f35
+vcpkg/scripts/buildsystems/vcpkg.cmake:
+	git -C vcpkg fetch || git clone --depth 1 --branch 2025.12.12 https://github.com/microsoft/vcpkg
+	cd vcpkg && ./bootstrap-vcpkg.sh
+
+setup-vcpkg: vcpkg/scripts/buildsystems/vcpkg.cmake
+	@echo 'Consider exporting VCPKG_TOOLCHAIN_PATH=$(PWD)/vcpkg/scripts/buildsystems/vcpkg.cmake'
+
+cleanup-vcpkg:
+	rm -rf vcpkg


### PR DESCRIPTION
Usage of the relevant Makefile commands (if included) would allow to setup a vcpkg clone top level in a given repository, to the correct hash, and bootstrat so to be ready for usage.

Note: the tag `2025.12.12` correspond to commit `84bab45d415d22042bd0b9081aea57f362da3f35`, the one currently used in `v1.5-variegata` and `main`.