### PR TITLE
Revert "Use arm for linux to support arm64 and amd64 archs"

### DIFF
--- a/config/distribution_matrix.json
+++ b/config/distribution_matrix.json
@@ -6,7 +6,7 @@
         "runner": "ubuntu-24.04",
         "vcpkg_target_triplet": "x64-linux-release",
         "vcpkg_host_triplet": "x64-linux-release",
-        "run_in_reduced_ci_mode": false,
+        "run_in_reduced_ci_mode": true,
         "opt_in": false
       },
       {
@@ -14,7 +14,7 @@
         "runner": "ubuntu-24.04-arm",
         "vcpkg_target_triplet": "arm64-linux-release",
         "vcpkg_host_triplet": "arm64-linux-release",
-        "run_in_reduced_ci_mode": true,
+        "run_in_reduced_ci_mode": false,
         "opt_in": false
       },
       {


### PR DESCRIPTION
This reverts commit 76bc4e111324bdc61a74f450097419365499dca4.

I think given the current testing it's limited to non existing while cross compiling, I think inverting it's a better fit.

EDIT: This might also have triggered failures in  extension workflows for PRs, see context at https://github.com/duckdb/duckdb/pull/21034#issuecomment-3938648869