### PR TITLE
Bring back top level category, to avoid empty matrix.duckdb_arch for …

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -218,7 +218,7 @@ jobs:
           cat "$GITHUB_OUTPUT"
 
   linux:
-    name: ${{ matrix.duckdb_arch }}
+    name: Linux ${{ matrix.duckdb_arch }}
     runs-on: ${{ matrix.runner }}
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.linux_matrix != '{}' && needs.generate_matrix.outputs.linux_matrix != '' }}
@@ -485,7 +485,7 @@ jobs:
           done
 
   macos:
-    name: ${{ matrix.duckdb_arch }}
+    name: MacOS ${{ matrix.duckdb_arch }}
     runs-on: macos-latest
     needs:
       - generate_matrix
@@ -733,7 +733,7 @@ jobs:
           done
 
   windows:
-    name: ${{ matrix.duckdb_arch }}
+    name: Windows ${{ matrix.duckdb_arch }}
     runs-on: ${{ matrix.runner }}
     needs:
       - generate_matrix
@@ -1003,7 +1003,7 @@ jobs:
           mv C:\rtools42\usr\bin\zstd.exe C:\rtools42\usr\bin\zstd-rtools.exe
 
   wasm:
-    name: ${{ matrix.duckdb_arch }}
+    name: Wasm ${{ matrix.duckdb_arch }}
     runs-on: ubuntu-latest
     needs:
       - generate_matrix


### PR DESCRIPTION
…completely skipped archs

Problem is that otherwise output for fully skipped arch categories would be not clear.