### PR TITLE
Update testing to v1.5.0 on v1.5-variegata

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -89,7 +89,7 @@ jobs:
     with:
       extension_name: delta
       override_repository: duckdb/duckdb_delta
-      override_ref: v1.5-variegata
+      override_ref: main
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       duckdb_version: v1.5.0

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -20,7 +20,7 @@ jobs:
       extension_name: quack
       override_repository: duckdb/extension-template
       override_ref: main
-      duckdb_version: v1.4.4
+      duckdb_version: v1.5.0
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3'
@@ -32,7 +32,7 @@ jobs:
       extension_name: capi_quack
       override_repository: duckdb/extension-template-c
       override_ref: main
-      duckdb_version: v1.4.4
+      duckdb_version: v1.5.0
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3;unixodbc'
@@ -50,7 +50,7 @@ jobs:
       extension_name: quack
       override_repository: duckdb/extension-template
       override_ref: main
-      duckdb_version: v1.4.4
+      duckdb_version: v1.5.0
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp;go;python3;downgraded_aws_cli;'
@@ -73,7 +73,7 @@ jobs:
       extension_name: rusty_quack
       override_repository: duckdb/extension-template-rs
       override_ref: main
-      duckdb_version: v1.4.4
+      duckdb_version: v1.5.0
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'rust;python3'
@@ -89,10 +89,10 @@ jobs:
     with:
       extension_name: delta
       override_repository: duckdb/duckdb_delta
-      override_ref: v1.4-andium
+      override_ref: v1.5-variegata
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
-      duckdb_version: v1.4.4
+      duckdb_version: v1.5.0
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64'
       extra_toolchains: 'rust'
       save_cache: ${{ github.event_name != 'pull_request' }}

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ DuckDB's [Extension Template](https://github.com/duckdb/extension-template/actio
 | Extension-ci-tools Branch | DuckDB target version | Actively maintained? |
 |---------------------------|-----------------------|----------------------|
 | main                      | main                  | yes                  |
+| v1.5.0                    | v1.5.0                | yes                  |
 | v1.4.4                    | v1.4.4                | yes                  |
-| v1.4.3                    | v1.4.3                | no                  |
+| v1.4.3                    | v1.4.3                | no                   |
 | v1.4.2                    | v1.4.2                | no                   |
 | v1.4.1                    | v1.4.1                | no                   |
 | v1.4.0                    | v1.4.0                | no                   |


### PR DESCRIPTION
Merges the changes [here](https://github.com/duckdb/extension-ci-tools/pull/338) in to `v1.5-variegata`.