### PR TITLE
Change mkdir -p call to be compatible with Windows

### DIFF
--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -155,22 +155,22 @@ ifneq ($(TIDY_CHECKS),)
 endif
 
 debug: ${EXTENSION_CONFIG_STEP}
-	mkdir -p build/debug
+	mkdir -p build/debug && true
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_DEBUG_FLAGS) $(VCPKG_MANIFEST_FLAGS) -DCMAKE_BUILD_TYPE=Debug -S $(DUCKDB_SRCDIR) -B build/debug
 	cmake --build build/debug --config Debug
 
 release: ${EXTENSION_CONFIG_STEP}
-	mkdir -p build/release
+	mkdir -p build/release && true
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) $(VCPKG_MANIFEST_FLAGS) -DCMAKE_BUILD_TYPE=Release -S $(DUCKDB_SRCDIR) -B build/release
 	cmake --build build/release --config Release
 
 relassert: ${EXTENSION_CONFIG_STEP}
-	mkdir -p build/relassert
+	mkdir -p build/relassert && true
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) $(VCPKG_MANIFEST_FLAGS) -DCMAKE_BUILD_TYPE=RelWithDebInfo -S $(DUCKDB_SRCDIR) -DFORCE_ASSERT=1 -B build/relassert
 	cmake --build build/relassert --config RelWithDebInfo
 
 reldebug: ${EXTENSION_CONFIG_STEP}
-	mkdir -p build/reldebug
+	mkdir -p build/reldebug && true
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) $(VCPKG_MANIFEST_FLAGS) -DCMAKE_BUILD_TYPE=RelWithDebInfo -S $(DUCKDB_SRCDIR) -B build/reldebug
 	cmake --build build/reldebug
 
@@ -234,8 +234,8 @@ wasm_threads: wasm_pre_build_step ${EXTENSION_CONFIG_STEP_WASM}
 
 ###### Extension config step
 extension_configuration_default:
-	mkdir -p build/extension_configuration
-	mkdir -p duckdb/build/extension_configuration
+	mkdir -p build/extension_configuration && true
+	mkdir -p duckdb/build/extension_configuration && true
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_DEBUG_FLAGS) -DEXTENSION_CONFIG_BUILD=TRUE -DVCPKG_BUILD=1 -DCMAKE_BUILD_TYPE=Debug -S $(DUCKDB_SRCDIR) -B build/extension_configuration
 	cmake --build build/extension_configuration
 	cp duckdb/build/extension_configuration/vcpkg.json build/extension_configuration/vcpkg.json


### PR DESCRIPTION
When `mkdir -p` in a makefile targer is executed on Windows (without MSYS) the execution logic for two following invocations is different:

```make
mkdir -p foo/bar
cd foo/bar && ...
```
```make
mkdir -p foo/bar && cd foo/bar && ...
```

The former executes `mkdir` directrly, and fails with the following:

```cmd
> make
mkdir -p build/release
process_begin: CreateProcess(NULL, mkdir -p build/release, ...) failed.
make (e=2): The system cannot find the file specified.
make: *** [extension-ci-tools/makefiles/duckdb_extension.Makefile:163: release] Error 2
```

The second spaws bash (Git bash in this case) to run the whole command successfully.

While not all logic in `extension-ci-tools` makefiles is compatible with Windows, it is suggested to change `mkdir -p build/release` to `mkdir -p build/release && true` to have basic build targets compatible.