### PR TITLE
Update environment for Windows builds

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -809,7 +809,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Setup Rust
         if: (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;'))
@@ -832,13 +832,60 @@ jobs:
         run: |
           choco install winflexbison3
 
-      - name: Install Ninja build tool
+      - name: Install Dependencies 
+        shell: bash
         run: |
-          choco install ninja -y
+          choco install \
+            ccache \
+            jq \
+            make \
+            ninja \
+            zip \
+            --no-progress
 
-      - name: Install jq
+      - name: Install Mingw 
+        if: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw' }}
+        shell: bash
         run: |
-          choco install jq -y
+          choco install \
+            mingw --version 14.2.0 \
+            --no-progress
+
+      - name: Build Environment
+        shell: bash
+        run: |
+          # bash from Git
+          echo 'C:/Program Files/Git/bin' >> "${GITHUB_PATH}"
+          # make, ninja and ccache from Chocolatey
+          echo 'C:/ProgramData/Chocolatey/bin' >> "${GITHUB_PATH}"
+
+      - name: Build Environment for Mingw
+        if: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw' }}
+        shell: bash
+        run: |
+          # g++ from Chocolatey
+          echo 'C:/ProgramData/mingw64/mingw64/bin' >> "${GITHUB_PATH}"
+
+      - name: Build Environment Check
+        shell: cmd
+        run: |
+          where bash
+          bash --version
+          where make
+          make --version
+          where ninja
+          ninja --version
+          where ccache
+          ccache --version
+          echo %PATH%
+
+      - name: Build Environment Check for Mingw
+        if: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw' }}
+        shell: cmd
+        run: |
+          where g++
+          g++ --version
+          echo %PATH%
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
@@ -847,20 +894,6 @@ jobs:
           key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
           restore-keys: ccache-extension-distribution-${{ matrix.duckdb_arch }}-
           save: ${{ inputs.save_cache }}
-
-      - uses: r-lib/actions/setup-r@v2
-        if:  matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw'
-        with:
-          r-version: 'devel'
-          update-rtools: true
-          rtools-version: '42' # linker bug in 43
-
-      - name: setup rtools gcc for vcpkg
-        if:  matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw'
-        run: |
-          cp C:/rtools42/x86_64-w64-mingw32.static.posix/bin/gcc.exe C:/rtools42/x86_64-w64-mingw32.static.posix/bin/x86_64-w64-mingw32-gcc.exe
-          cp C:/rtools42/x86_64-w64-mingw32.static.posix/bin/g++.exe C:/rtools42/x86_64-w64-mingw32.static.posix/bin/x86_64-w64-mingw32-g++.exe
-          cp C:/rtools42/x86_64-w64-mingw32.static.posix/bin/gfortran.exe C:/rtools42/x86_64-w64-mingw32.static.posix/bin/x86_64-w64-mingw32-gfortran.exe
 
       - uses: actions/checkout@v4
         name: Checkout Extension CI tools
@@ -886,6 +919,7 @@ jobs:
 
       - name: Checkout DuckDB to version
         if: ${{ inputs.duckdb_version != '' }}
+        shell: cmd
         env:
           DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
         run: |
@@ -893,11 +927,13 @@ jobs:
 
       - name: Tag extension
         if: ${{inputs.extension_tag != ''}}
+        shell: cmd
         run: |
           git tag ${{ inputs.extension_tag }}
 
       - name: Tag DuckDB extension
         if: ${{inputs.duckdb_tag != ''}}
+        shell: cmd
         env:
           DUCKDB_TAG: ${{ inputs.duckdb_tag }}
         run: |
@@ -963,16 +999,33 @@ jobs:
           )
           make ${{ inputs.build_type }}
 
-      - name: Test extension
-        if: ${{ inputs.skip_tests == false }}
+      - name: Copy Mingw Libs
+        if: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw' }}
+        shell: bash
+        run: |
+          export SRC_DIR=C:/ProgramData/mingw64/mingw64/x86_64-w64-mingw32/lib
+          export DEST_DIR=./build/${{ inputs.build_type }}/test
+          cp "${SRC_DIR}"/libgcc_s_seh-1.dll "${DEST_DIR}"/
+          cp "${SRC_DIR}"/libstdc++-6.dll "${DEST_DIR}"/
+          cp "${SRC_DIR}"/libwinpthread-1.dll "${DEST_DIR}"/
+
+      - name: Test extension MSVC
+        if: ${{ inputs.skip_tests == false && matrix.duckdb_arch != 'windows_amd64_rtools' && matrix.duckdb_arch != 'windows_amd64_mingw' }}
         shell: bash
         env:
-          DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-          DUCKDB_PLATFORM_RTOOLS: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 1 || 0 }}
           SUBSET_EXTENSIONS_TESTS: ${{ inputs.extensions_test_selection }}
         run: |
           eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
           make test_${{ inputs.build_type }}
+
+      # unittest.exe built by MinGW has broken wildcard filtering
+      # so we just run it directly with no arguments
+      - name: Test extension Mingw
+        if: ${{ inputs.skip_tests == false && (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') }}
+        shell: bash
+        run: |
+          eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
+          ./build/${{ inputs.build_type }}/test/unittest.exe
 
       - uses: actions/upload-artifact@v4
         if: ${{ !inputs.upload_all_extensions }}
@@ -999,12 +1052,6 @@ jobs:
             cat $filename;
             echo Done printing logs for $filename
           done
-
-      - name: Move rtools supplied zstd out of the way, so ccache can work
-        if: (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw')
-        shell: cmd
-        run: |
-          mv C:\rtools42\usr\bin\zstd.exe C:\rtools42\usr\bin\zstd-rtools.exe
 
   wasm:
     name: ${{ matrix.duckdb_arch }}


### PR DESCRIPTION
This is a follow-up to the duckdb/duckdb#21371 PR.

It changes the environment on Windows to use:

 - native Windows builds of GNU `make` and `ccache`
 - GCC 14.2 (only for MinGW)

Ref: duckdblabs/duckdb-internal#8273, duckdblabs/duckdb-internal#8416