### PR TITLE
Allow custom runners in extension's CI jobs

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -46,6 +46,24 @@ jobs:
       opt_in_archs: 'windows_arm64;linux_amd64_musl;linux_arm64_musl;windows_amd64_mingw;'
       save_cache: ${{ github.event_name != 'pull_request' }}
 
+  extension-template-custom-runners:
+    name: Extension template (custom runners)
+    uses: ./.github/workflows/_extension_distribution.yml
+    with:
+      extension_name: capi_quack
+      artifact_postfix: custom-runners
+      override_repository: duckdb/extension-template-c
+      override_ref: main
+      duckdb_version: v1.4.4
+      override_ci_tools_repository: ${{ github.repository }}
+      ci_tools_version: ${{ github.sha }}
+      runners: '{"linux_x64":"ubuntu-latest"}'
+      exclude_archs: 'wasm_eh;windows_amd64'
+      save_cache: false
+      post_build_command: |
+        echo "matrix runner: $MATRIX_RUNNER"
+        test "$MATRIX_RUNNER" = "ubuntu-latest"
+
   extension-template-main:
     name: Extension template
     uses: ./.github/workflows/_extension_distribution.yml

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -58,7 +58,7 @@ jobs:
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       runners: '{"linux_x64":"ubuntu-latest"}'
-      exclude_archs: 'wasm_eh;windows_amd64'
+      exclude_archs: 'linux_arm64;osx_amd64;osx_arm64;wasm_eh;wasm_mvp;wasm_threads;windows_amd64_mingw;windows_amd64'
       save_cache: false
       post_build_command: |
         echo "matrix runner: $MATRIX_RUNNER"

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -178,6 +178,7 @@ on:
 
 env:
   VCPKG_BINARY_SOURCES: ${{inputs.vcpkg_binary_sources == '' && 'clear;http,https://vcpkg-cache.duckdb.org,read' || inputs.vcpkg_binary_sources }}
+  USE_DEFAULT_RUNNERS: ${{ inputs.runners == '{}' }}
 
 jobs:
   generate_matrix:
@@ -274,18 +275,22 @@ jobs:
           rm package.list
 
       - name: Restart docker to run on /mnt
+        if: ${{ env.USE_DEFAULT_RUNNERS == 'true' }}
         run: |
           sudo systemctl stop docker
 
       - name: Configure Docker with custom data directory
+        if: ${{ env.USE_DEFAULT_RUNNERS == 'true' }}
         run: |
           sudo mkdir -p /mnt/docker-data
           echo '{ "data-root": "/mnt/docker-data" }' | sudo tee /etc/docker/daemon.json
 
       - name: Start Docker with updated storage path
+        if: ${{ env.USE_DEFAULT_RUNNERS == 'true' }}
         run: sudo systemctl start docker
 
       - name: Verify Docker storage path
+        if: ${{ env.USE_DEFAULT_RUNNERS == 'true' }}
         run: docker info | grep "Docker Root Dir"
 
       - uses: actions/checkout@v4

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -171,6 +171,10 @@ on:
         required: false
         type: string
         default: 'regular'
+      runners:
+        required: false
+        type: string
+        default: '{}'
 
 env:
   VCPKG_BINARY_SOURCES: ${{inputs.vcpkg_binary_sources == '' && 'clear;http,https://vcpkg-cache.duckdb.org,read' || inputs.vcpkg_binary_sources }}
@@ -212,6 +216,7 @@ jobs:
             --input extension-ci-tools/config/distribution_matrix.json \
             --exclude "${{ inputs.exclude_archs }}" \
             --opt-in "${{ inputs.opt_in_archs }}" \
+            --runners '${{ inputs.runners }}' \
             --reduced-ci-mode "${{ inputs.reduced_ci_mode }}" \
             --out "$GITHUB_OUTPUT"
           echo "extbuild matrix output:"

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -254,7 +254,7 @@ jobs:
       - name: Free disk space 1
         uses: endersonmenezes/free-disk-space@v2.1.1
         continue-on-error: true
-        if: inputs.run_disk_clean_step
+        if: ${{ inputs.run_disk_clean_step && env.USE_DEFAULT_RUNNERS == 'true' }}
         with:
 #          remove_android: true # ~9.5GB in #52s
 #          remove_dotnet: true
@@ -267,7 +267,7 @@ jobs:
 
       - name: Free disk space 2
         continue-on-error: true
-        if: inputs.run_disk_clean_step
+        if: ${{ inputs.run_disk_clean_step && env.USE_DEFAULT_RUNNERS == 'true' }}
         run: |
           docker images -a -q > package.list
           if [ -s package.list ]; then

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -175,6 +175,10 @@ on:
         required: false
         type: string
         default: '{}'
+      post_build_command:
+        required: false
+        type: string
+        default: ""
 
 env:
   VCPKG_BINARY_SOURCES: ${{inputs.vcpkg_binary_sources == '' && 'clear;http,https://vcpkg-cache.duckdb.org,read' || inputs.vcpkg_binary_sources }}
@@ -448,6 +452,13 @@ jobs:
       - name: Build extension (inside Docker)
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make ${{ inputs.build_type }}
+
+      - name: Run post build command
+        if: ${{ inputs.post_build_command != '' }}
+        shell: bash
+        env:
+          MATRIX_RUNNER: ${{ matrix.runner }}
+        run: ${{ inputs.post_build_command }}
 
       - name: Save Ccache
         if: ${{ inputs.save_cache }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -488,7 +488,7 @@ jobs:
 
   macos:
     name: ${{ matrix.duckdb_arch }}
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     needs:
       - generate_matrix
       - linux
@@ -1008,7 +1008,7 @@ jobs:
 
   wasm:
     name: ${{ matrix.duckdb_arch }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs:
       - generate_matrix
       - linux

--- a/config/distribution_matrix.json
+++ b/config/distribution_matrix.json
@@ -39,6 +39,7 @@
     "include": [
       {
         "duckdb_arch": "osx_amd64",
+        "runner": "macos-latest",
         "osx_build_arch": "x86_64",
         "vcpkg_target_triplet": "x64-osx-release",
         "vcpkg_host_triplet": "arm64-osx-release",
@@ -47,6 +48,7 @@
       },
       {
         "duckdb_arch": "osx_arm64",
+        "runner": "macos-latest",
         "osx_build_arch": "arm64",
         "vcpkg_target_triplet": "arm64-osx-release",
         "vcpkg_host_triplet": "arm64-osx-release",
@@ -87,6 +89,7 @@
     "include": [
       {
         "duckdb_arch": "wasm_mvp",
+        "runner": "ubuntu-latest",
         "vcpkg_target_triplet": "wasm32-emscripten",
         "vcpkg_host_triplet": "x64-linux",
         "run_in_reduced_ci_mode": false,
@@ -94,6 +97,7 @@
       },
       {
         "duckdb_arch": "wasm_eh",
+        "runner": "ubuntu-latest",
         "vcpkg_target_triplet": "wasm32-emscripten",
         "vcpkg_host_triplet": "x64-linux",
         "run_in_reduced_ci_mode": true,
@@ -101,6 +105,7 @@
       },
       {
         "duckdb_arch": "wasm_threads",
+        "runner": "ubuntu-latest",
         "vcpkg_target_triplet": "wasm32-emscripten",
         "vcpkg_host_triplet": "x64-linux",
         "run_in_reduced_ci_mode": false,

--- a/scripts/extbuild/cmd/extbuild/github_event_test.go
+++ b/scripts/extbuild/cmd/extbuild/github_event_test.go
@@ -106,8 +106,8 @@ func TestMatrixSubcommandPullRequestEnablesReducedCIWhenAuto(t *testing.T) {
 	inputJSON := `{
   "linux": {
     "include": [
-      {"duckdb_arch":"linux_amd64","run_in_reduced_ci_mode":true,"opt_in":false},
-      {"duckdb_arch":"linux_arm64","run_in_reduced_ci_mode":false,"opt_in":false}
+      {"duckdb_arch":"linux_amd64","runner":"ubuntu-24.04","run_in_reduced_ci_mode":true,"opt_in":false},
+      {"duckdb_arch":"linux_arm64","runner":"ubuntu-24.04-arm","run_in_reduced_ci_mode":false,"opt_in":false}
     ]
   }
 }`

--- a/scripts/extbuild/cmd/extbuild/matrix.go
+++ b/scripts/extbuild/cmd/extbuild/matrix.go
@@ -16,6 +16,7 @@ func newMatrixCommand() *cobra.Command {
 		archsRaw         string
 		excludeRaw       string
 		optInRaw         string
+		runnerJSON       string
 		reducedCIModeRaw string
 		outPath          string
 		deployOnly       bool
@@ -61,6 +62,7 @@ func newMatrixCommand() *cobra.Command {
 				Exclude:       excludeRaw,
 				OptIn:         optInRaw,
 				ReducedCIMode: reducedCIMode,
+				RunnerJSON:    runnerJSON,
 			})
 			if err != nil {
 				return fmt.Errorf("compute platform matrices: %w", err)
@@ -104,6 +106,7 @@ func newMatrixCommand() *cobra.Command {
 	cmd.Flags().StringVar(&archsRaw, "arch", "", "Comma-separated list of arch tokens (amd64;arm64)")
 	cmd.Flags().StringVar(&excludeRaw, "exclude", "", "Comma-separated list of duckdb_arch values to exclude")
 	cmd.Flags().StringVar(&optInRaw, "opt-in", "", "Comma-separated list of opt-in duckdb_arch values")
+	cmd.Flags().StringVar(&runnerJSON, "runners", "{}", "JSON object with runner overrides keyed by selector or duckdb_arch")
 	cmd.Flags().StringVar(&reducedCIModeRaw, "reduced-ci-mode", "", "Reduced CI mode: auto|enabled|disabled")
 	cmd.Flags().StringVar(&outPath, "out", "", "Path to write GitHub output lines")
 	cmd.Flags().BoolVar(&deployOnly, "deploy", false, "Emit only deploy_matrix output with duckdb_arch values")

--- a/scripts/extbuild/cmd/extbuild/matrix_test.go
+++ b/scripts/extbuild/cmd/extbuild/matrix_test.go
@@ -65,16 +65,19 @@ func TestComputePlatformMatrices(t *testing.T) {
     "include": [
       {
         "duckdb_arch": "wasm_mvp",
+        "runner": "ubuntu-latest",
         "run_in_reduced_ci_mode": true,
         "opt_in": false
       },
       {
         "duckdb_arch": "wasm_eh",
+        "runner": "ubuntu-latest",
         "run_in_reduced_ci_mode": false,
         "opt_in": false
       },
       {
         "duckdb_arch": "wasm_threads",
+        "runner": "ubuntu-latest",
         "run_in_reduced_ci_mode": false,
         "opt_in": false
       }
@@ -212,13 +215,13 @@ func TestMatrixSubcommandWritesOutputFile(t *testing.T) {
 	inputJSON := `{
   "linux": {
     "include": [
-      {"duckdb_arch":"linux_amd64","run_in_reduced_ci_mode":true,"opt_in":false},
-      {"duckdb_arch":"linux_arm64","run_in_reduced_ci_mode":true,"opt_in":false}
+      {"duckdb_arch":"linux_amd64","runner":"ubuntu-24.04","run_in_reduced_ci_mode":true,"opt_in":false},
+      {"duckdb_arch":"linux_arm64","runner":"ubuntu-24.04-arm","run_in_reduced_ci_mode":true,"opt_in":false}
     ]
   },
   "windows": {
     "include": [
-      {"duckdb_arch":"windows_amd64","run_in_reduced_ci_mode":true,"opt_in":false}
+      {"duckdb_arch":"windows_amd64","runner":"windows-latest","run_in_reduced_ci_mode":true,"opt_in":false}
     ]
   }
 }`
@@ -326,13 +329,13 @@ func TestMatrixSubcommandDeployMode(t *testing.T) {
 	inputJSON := `{
   "linux": {
     "include": [
-      {"duckdb_arch":"linux_amd64","run_in_reduced_ci_mode":true,"opt_in":false},
-      {"duckdb_arch":"linux_arm64","run_in_reduced_ci_mode":true,"opt_in":false}
+      {"duckdb_arch":"linux_amd64","runner":"ubuntu-24.04","run_in_reduced_ci_mode":true,"opt_in":false},
+      {"duckdb_arch":"linux_arm64","runner":"ubuntu-24.04-arm","run_in_reduced_ci_mode":true,"opt_in":false}
     ]
   },
   "windows": {
     "include": [
-      {"duckdb_arch":"windows_amd64","run_in_reduced_ci_mode":true,"opt_in":false}
+      {"duckdb_arch":"windows_amd64","runner":"windows-latest","run_in_reduced_ci_mode":true,"opt_in":false}
     ]
   }
 }`

--- a/scripts/extbuild/cmd/extbuild/matrix_test.go
+++ b/scripts/extbuild/cmd/extbuild/matrix_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/duckdb/extension-ci-tools/internal/distmatrix"
@@ -173,6 +175,18 @@ func TestComputePlatformMatrices(t *testing.T) {
 				"windows": {},
 			},
 		},
+		{
+			name: "linux runner aliases override generated matrix runners",
+			opts: distmatrix.ComputeOptions{
+				Platform:   "linux",
+				Arch:       "amd64;arm64",
+				OptIn:      "linux_amd64_musl",
+				RunnerJSON: `{"linux_x64":"duckdb-linux-x64","linux_arm64":"duckdb-linux-arm64"}`,
+			},
+			expected: map[string][]string{
+				"linux": {"linux_amd64", "linux_amd64_musl", "linux_arm64"},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -222,6 +236,78 @@ func TestMatrixSubcommandWritesOutputFile(t *testing.T) {
 		assert.Contains(t, content, "linux_matrix={")
 		assert.Contains(t, content, "windows_matrix={")
 	}
+}
+
+func TestMatrixSubcommandAppliesRunnerOverrides(t *testing.T) {
+	t.Parallel()
+
+	inputJSON := `{
+  "linux": {
+    "include": [
+      {"duckdb_arch":"linux_amd64","runner":"ubuntu-24.04","run_in_reduced_ci_mode":true,"opt_in":false},
+      {"duckdb_arch":"linux_arm64","runner":"ubuntu-24.04-arm","run_in_reduced_ci_mode":true,"opt_in":false},
+      {"duckdb_arch":"linux_arm64_musl","runner":"ubuntu-24.04-arm","run_in_reduced_ci_mode":true,"opt_in":true}
+    ]
+  }
+}`
+
+	outputPath, stdout := runMatrixCommand(t, inputJSON, []string{
+		"--platform", "linux",
+		"--arch", "amd64;arm64",
+		"--opt-in", "linux_arm64_musl",
+		"--runners", `{"linux_x64":"duckdb-linux-x64","linux_arm64":"duckdb-linux-arm64"}`,
+	})
+
+	out, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	line := strings.TrimSpace(string(out))
+	require.True(t, strings.HasPrefix(line, "linux_matrix="))
+
+	var matrix distmatrix.PlatformMatrix
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimPrefix(line, "linux_matrix=")), &matrix))
+	require.Len(t, matrix.Include, 3)
+
+	assert.Equal(t, "linux_amd64", matrix.Include[0].DuckDBArch)
+	assert.Equal(t, "duckdb-linux-x64", matrix.Include[0].Runner)
+
+	assert.Equal(t, "linux_arm64", matrix.Include[1].DuckDBArch)
+	assert.Equal(t, "duckdb-linux-arm64", matrix.Include[1].Runner)
+
+	assert.Equal(t, "linux_arm64_musl", matrix.Include[2].DuckDBArch)
+	assert.Equal(t, "duckdb-linux-arm64", matrix.Include[2].Runner)
+
+	assert.Contains(t, stdout, "duckdb-linux-x64")
+	assert.Contains(t, stdout, "duckdb-linux-arm64")
+}
+
+func TestMatrixSubcommandPreservesRunnerWhenNotOverridden(t *testing.T) {
+	t.Parallel()
+
+	inputJSON := `{
+  "windows": {
+    "include": [
+      {"duckdb_arch":"windows_amd64","runner":"windows-latest","run_in_reduced_ci_mode":true,"opt_in":false}
+    ]
+  }
+}`
+
+	outputPath, _ := runMatrixCommand(t, inputJSON, []string{
+		"--platform", "windows",
+		"--runners", `{"linux_x64":"duckdb-linux-x64","linux_arm64":"duckdb-linux-arm64"}`,
+	})
+
+	out, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	line := strings.TrimSpace(string(out))
+	require.True(t, strings.HasPrefix(line, "windows_matrix="))
+
+	var matrix distmatrix.PlatformMatrix
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimPrefix(line, "windows_matrix=")), &matrix))
+	require.Len(t, matrix.Include, 1)
+	assert.Equal(t, "windows_amd64", matrix.Include[0].DuckDBArch)
+	assert.Equal(t, "windows-latest", matrix.Include[0].Runner)
 }
 
 func TestMatrixSubcommandWithoutArgs(t *testing.T) {

--- a/scripts/extbuild/internal/distmatrix/config_test.go
+++ b/scripts/extbuild/internal/distmatrix/config_test.go
@@ -63,22 +63,22 @@ func TestRunnerOverrideAliasesCoverAllRunnerEntriesInDistributionMatrix(t *testi
 	matrix, err := ParseMatrixFile(data)
 	require.NoError(t, err)
 
-	expectedAliases := map[string][]string{
-		"linux_amd64":         {"linux_x64"},
-		"linux_arm64":         {"linux_arm64"},
-		"linux_amd64_musl":    {"linux_x64"},
-		"linux_arm64_musl":    {"linux_arm64"},
-		"osx_amd64":           {"macos_x64"},
-		"osx_arm64":           {"macos_arm64", "macos_14_arm64"},
-		"windows_amd64":       {"windows_x64"},
-		"windows_arm64":       {"windows_arm64"},
-		"windows_amd64_mingw": {"windows_x64"},
-		"wasm_mvp":            {"linux_x64"},
-		"wasm_eh":             {"linux_x64"},
-		"wasm_threads":        {"linux_x64"},
+	expectedAliases := map[string]string{
+		"linux_amd64":         "linux_x64",
+		"linux_arm64":         "linux_arm64",
+		"linux_amd64_musl":    "linux_x64",
+		"linux_arm64_musl":    "linux_arm64",
+		"osx_amd64":           "macos_x64",
+		"osx_arm64":           "macos_arm64",
+		"windows_amd64":       "windows_x64",
+		"windows_arm64":       "windows_arm64",
+		"windows_amd64_mingw": "windows_x64",
+		"wasm_mvp":            "linux_x64",
+		"wasm_eh":             "linux_x64",
+		"wasm_threads":        "linux_x64",
 	}
 
-	actualAliases := map[string][]string{}
+	actualAliases := map[string]string{}
 	for _, cfg := range matrix {
 		for _, entry := range cfg.Include {
 			require.NotNil(t, entry.Runner, "runner must be set for %s", entry.DuckDBArch)

--- a/scripts/extbuild/internal/distmatrix/config_test.go
+++ b/scripts/extbuild/internal/distmatrix/config_test.go
@@ -53,3 +53,39 @@ func TestParseMatrixFileRejectsUnknownFields(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "unknown field")
 }
+
+func TestRunnerOverrideAliasesCoverAllRunnerEntriesInDistributionMatrix(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "config", "distribution_matrix.json"))
+	require.NoError(t, err)
+
+	matrix, err := ParseMatrixFile(data)
+	require.NoError(t, err)
+
+	expectedAliases := map[string][]string{
+		"linux_amd64":         {"linux_x64"},
+		"linux_arm64":         {"linux_arm64"},
+		"linux_amd64_musl":    {"linux_x64"},
+		"linux_arm64_musl":    {"linux_arm64"},
+		"osx_amd64":           {"macos_x64"},
+		"osx_arm64":           {"macos_arm64", "macos_14_arm64"},
+		"windows_amd64":       {"windows_x64"},
+		"windows_arm64":       {"windows_arm64"},
+		"windows_amd64_mingw": {"windows_x64"},
+		"wasm_mvp":            {"linux_x64"},
+		"wasm_eh":             {"linux_x64"},
+		"wasm_threads":        {"linux_x64"},
+	}
+
+	actualAliases := map[string][]string{}
+	for _, cfg := range matrix {
+		for _, entry := range cfg.Include {
+			require.NotNil(t, entry.Runner, "runner must be set for %s", entry.DuckDBArch)
+
+			actualAliases[entry.DuckDBArch] = runnerOverrideAliases(entry.DuckDBArch)
+		}
+	}
+
+	assert.Equal(t, expectedAliases, actualAliases)
+}

--- a/scripts/extbuild/internal/distmatrix/config_test.go
+++ b/scripts/extbuild/internal/distmatrix/config_test.go
@@ -81,7 +81,7 @@ func TestRunnerOverrideAliasesCoverAllRunnerEntriesInDistributionMatrix(t *testi
 	actualAliases := map[string]string{}
 	for _, cfg := range matrix {
 		for _, entry := range cfg.Include {
-			require.NotNil(t, entry.Runner, "runner must be set for %s", entry.DuckDBArch)
+			require.NotEmpty(t, entry.Runner, "runner must be set for %s", entry.DuckDBArch)
 
 			actualAliases[entry.DuckDBArch] = runnerOverrideAliases(entry.DuckDBArch)
 		}

--- a/scripts/extbuild/internal/distmatrix/matrix.go
+++ b/scripts/extbuild/internal/distmatrix/matrix.go
@@ -24,7 +24,7 @@ type PlatformConfig struct {
 
 type Entry struct {
 	DuckDBArch   string  `json:"duckdb_arch"`
-	Runner       *string `json:"runner"`
+	Runner       string  `json:"runner"`
 	OSXBuildArch *string `json:"osx_build_arch"`
 
 	VCPKGTargetTriplet string `json:"vcpkg_target_triplet"`
@@ -75,6 +75,13 @@ func ParseMatrixFile(data []byte) (MatrixFile, error) {
 	}
 	if err := decoder.Decode(new(struct{})); err != io.EOF {
 		return nil, errors.New("invalid JSON: multiple top-level values")
+	}
+	for platform, cfg := range matrix {
+		for _, entry := range cfg.Include {
+			if strings.TrimSpace(entry.Runner) == "" {
+				return nil, fmt.Errorf("platform %s entry %s has empty runner", platform, entry.DuckDBArch)
+			}
+		}
 	}
 	return matrix, nil
 }
@@ -286,14 +293,9 @@ func ParseRunnerOverrides(raw string) (RunnerOverrides, error) {
 }
 
 func toPlatformOutput(entry Entry) PlatformOutput {
-	runner := ""
-	if entry.Runner != nil {
-		runner = *entry.Runner
-	}
-
 	return PlatformOutput{
 		DuckDBArch:         entry.DuckDBArch,
-		Runner:             runner,
+		Runner:             entry.Runner,
 		OSXBuildArch:       entry.OSXBuildArch,
 		VCPKGTargetTriplet: entry.VCPKGTargetTriplet,
 		VCPKGHostTriplet:   entry.VCPKGHostTriplet,

--- a/scripts/extbuild/internal/distmatrix/matrix.go
+++ b/scripts/extbuild/internal/distmatrix/matrix.go
@@ -39,7 +39,7 @@ type PlatformMatrix struct {
 
 type PlatformOutput struct {
 	DuckDBArch   string  `json:"duckdb_arch"`
-	Runner       *string `json:"runner,omitempty"`
+	Runner       string  `json:"runner,omitempty"`
 	OSXBuildArch *string `json:"osx_build_arch,omitempty"`
 
 	VCPKGTargetTriplet string `json:"vcpkg_target_triplet,omitempty"`
@@ -60,7 +60,10 @@ type ComputeOptions struct {
 	Exclude       string
 	OptIn         string
 	ReducedCIMode ReducedCIMode
+	RunnerJSON    string
 }
+
+type RunnerOverrides map[string]string
 
 func ParseMatrixFile(data []byte) (MatrixFile, error) {
 	decoder := json.NewDecoder(bytes.NewReader(data))
@@ -77,6 +80,11 @@ func ParseMatrixFile(data []byte) (MatrixFile, error) {
 }
 
 func ComputePlatformMatrices(matrix MatrixFile, opts ComputeOptions) (map[string]PlatformMatrix, error) {
+	runnerOverrides, err := ParseRunnerOverrides(opts.RunnerJSON)
+	if err != nil {
+		return nil, err
+	}
+
 	platforms := splitList(opts.Platform)
 	if len(platforms) == 0 {
 		platforms = sortedMatrixPlatforms(matrix)
@@ -115,7 +123,11 @@ func ComputePlatformMatrices(matrix MatrixFile, opts ComputeOptions) (map[string
 		filtered := make([]PlatformOutput, 0, len(cfg.Include))
 		for _, entry := range cfg.Include {
 			if includeEntry(entry, archTokens, excludedSet, reducedCI, optInSet) {
-				filtered = append(filtered, toPlatformOutput(entry))
+				output := toPlatformOutput(entry)
+				if override, ok := runnerOverrides.lookup(platform, entry.DuckDBArch); ok {
+					output.Runner = override
+				}
+				filtered = append(filtered, output)
 			}
 		}
 
@@ -241,12 +253,82 @@ func toSet(values []string) map[string]struct{} {
 	return set
 }
 
+func ParseRunnerOverrides(raw string) (RunnerOverrides, error) {
+	if strings.TrimSpace(raw) == "" {
+		return RunnerOverrides{}, nil
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.DisallowUnknownFields()
+
+	var overrides map[string]string
+	if err := decoder.Decode(&overrides); err != nil {
+		return nil, fmt.Errorf("parse runner overrides: %w", err)
+	}
+	if err := decoder.Decode(new(struct{})); err != io.EOF {
+		return nil, errors.New("parse runner overrides: invalid JSON: multiple top-level values")
+	}
+
+	result := make(RunnerOverrides, len(overrides))
+	for key, value := range overrides {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return nil, errors.New("parse runner overrides: override key cannot be empty")
+		}
+		if value == "" {
+			return nil, fmt.Errorf("parse runner overrides: override value for %q cannot be empty", key)
+		}
+		result[key] = value
+	}
+
+	return result, nil
+}
+
 func toPlatformOutput(entry Entry) PlatformOutput {
+	runner := ""
+	if entry.Runner != nil {
+		runner = *entry.Runner
+	}
+
 	return PlatformOutput{
 		DuckDBArch:         entry.DuckDBArch,
-		Runner:             entry.Runner,
+		Runner:             runner,
 		OSXBuildArch:       entry.OSXBuildArch,
 		VCPKGTargetTriplet: entry.VCPKGTargetTriplet,
 		VCPKGHostTriplet:   entry.VCPKGHostTriplet,
+	}
+}
+
+func (o RunnerOverrides) lookup(platform string, duckdbArch string) (string, bool) {
+	if len(o) == 0 {
+		return "", false
+	}
+
+	if override, ok := o[duckdbArch]; ok {
+		return override, true
+	}
+
+	for _, key := range runnerOverrideAliases(platform, duckdbArch) {
+		if override, ok := o[key]; ok {
+			return override, true
+		}
+	}
+
+	return "", false
+}
+
+func runnerOverrideAliases(platform string, duckdbArch string) []string {
+	if platform != "linux" {
+		return nil
+	}
+
+	switch duckdbArch {
+	case "linux_amd64", "linux_amd64_musl":
+		return []string{"linux_x64"}
+	case "linux_arm64", "linux_arm64_musl":
+		return []string{"linux_arm64"}
+	default:
+		return nil
 	}
 }

--- a/scripts/extbuild/internal/distmatrix/matrix.go
+++ b/scripts/extbuild/internal/distmatrix/matrix.go
@@ -124,7 +124,7 @@ func ComputePlatformMatrices(matrix MatrixFile, opts ComputeOptions) (map[string
 		for _, entry := range cfg.Include {
 			if includeEntry(entry, archTokens, excludedSet, reducedCI, optInSet) {
 				output := toPlatformOutput(entry)
-				if override, ok := runnerOverrides.lookup(platform, entry.DuckDBArch); ok {
+				if override, ok := runnerOverrides.lookup(entry.DuckDBArch); ok {
 					output.Runner = override
 				}
 				filtered = append(filtered, output)
@@ -300,7 +300,7 @@ func toPlatformOutput(entry Entry) PlatformOutput {
 	}
 }
 
-func (o RunnerOverrides) lookup(platform string, duckdbArch string) (string, bool) {
+func (o RunnerOverrides) lookup(duckdbArch string) (string, bool) {
 	if len(o) == 0 {
 		return "", false
 	}
@@ -309,7 +309,7 @@ func (o RunnerOverrides) lookup(platform string, duckdbArch string) (string, boo
 		return override, true
 	}
 
-	for _, key := range runnerOverrideAliases(platform, duckdbArch) {
+	for _, key := range runnerOverrideAliases(duckdbArch) {
 		if override, ok := o[key]; ok {
 			return override, true
 		}
@@ -318,17 +318,23 @@ func (o RunnerOverrides) lookup(platform string, duckdbArch string) (string, boo
 	return "", false
 }
 
-func runnerOverrideAliases(platform string, duckdbArch string) []string {
-	if platform != "linux" {
-		return nil
-	}
-
+func runnerOverrideAliases(duckdbArch string) []string {
 	switch duckdbArch {
 	case "linux_amd64", "linux_amd64_musl":
 		return []string{"linux_x64"}
 	case "linux_arm64", "linux_arm64_musl":
 		return []string{"linux_arm64"}
-	default:
-		return nil
+	case "osx_amd64":
+		return []string{"macos_x64"}
+	case "osx_arm64":
+		return []string{"macos_arm64", "macos_14_arm64"}
+	case "windows_amd64", "windows_amd64_mingw":
+		return []string{"windows_x64"}
+	case "windows_arm64":
+		return []string{"windows_arm64"}
+	case "wasm_mvp", "wasm_eh", "wasm_threads":
+		return []string{"linux_x64"}
 	}
+
+	return nil
 }

--- a/scripts/extbuild/internal/distmatrix/matrix.go
+++ b/scripts/extbuild/internal/distmatrix/matrix.go
@@ -309,32 +309,32 @@ func (o RunnerOverrides) lookup(duckdbArch string) (string, bool) {
 		return override, true
 	}
 
-	for _, key := range runnerOverrideAliases(duckdbArch) {
-		if override, ok := o[key]; ok {
-			return override, true
-		}
+	key := runnerOverrideAliases(duckdbArch)
+	if key == "" {
+		return "", false
 	}
 
-	return "", false
+	override, ok := o[key]
+	return override, ok
 }
 
-func runnerOverrideAliases(duckdbArch string) []string {
+func runnerOverrideAliases(duckdbArch string) string {
 	switch duckdbArch {
 	case "linux_amd64", "linux_amd64_musl":
-		return []string{"linux_x64"}
+		return "linux_x64"
 	case "linux_arm64", "linux_arm64_musl":
-		return []string{"linux_arm64"}
+		return "linux_arm64"
 	case "osx_amd64":
-		return []string{"macos_x64"}
+		return "macos_x64"
 	case "osx_arm64":
-		return []string{"macos_arm64", "macos_14_arm64"}
+		return "macos_arm64"
 	case "windows_amd64", "windows_amd64_mingw":
-		return []string{"windows_x64"}
+		return "windows_x64"
 	case "windows_arm64":
-		return []string{"windows_arm64"}
+		return "windows_arm64"
 	case "wasm_mvp", "wasm_eh", "wasm_threads":
-		return []string{"linux_x64"}
+		return "linux_x64"
 	}
 
-	return nil
+	return ""
 }


### PR DESCRIPTION
Allow passing runners for the extensions' CI jobs.

For example, setting the workflow input parameter `runners` to:
```yaml
      runners: >-
        {
          "linux_x64": "namespace-profile-linux-x64",
          "linux_22_x64": "namespace-profile-linux-22-x64",
          "linux_arm64": "namespace-profile-linux-arm64",
          "macos_arm64": "namespace-profile-macos-arm64",
          "macos_14_arm64": "namespace-profile-macos-14-arm64"
        }
```
would enable specific namespace runners for the runner types listed as keys.

Note: the runners JSON object is constructed dynamically so the runners are selected in the DuckDB CI run depending on the repository name (forks use github runners, while DuckDB uses namespace runners).

When a key is missing in the provided `runners` JSON object, the CI job falls back to the field `runner` in [config/distribution_matrix.json](https://github.com/duckdb/extension-ci-tools/blob/main/config/distribution_matrix.json).

See also related PR for duckdb: https://github.com/duckdb/duckdb/pull/21575.

This is a duckdb CI [run](https://github.com/duckdb/duckdb/actions/runs/23489092831) that successfully uses namespace runners.