### PR TITLE
Add CUDA toolchain support for Linux Docker builds

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -179,6 +179,16 @@ on:
         required: false
         type: string
         default: ""
+      # CUDA GPU architectures to build for (e.g. "75;80;86;90a"). Empty disables CUDA arch specification.
+      cuda_archs:
+        required: false
+        type: string
+        default: ''
+      # CUDA version for vcpkg ports that need version-specific binaries
+      cuda_version:
+        required: false
+        type: string
+        default: '13'
 
 env:
   VCPKG_BINARY_SOURCES: ${{inputs.vcpkg_binary_sources == '' && 'clear;http,https://vcpkg-cache.duckdb.org,read' || inputs.vcpkg_binary_sources }}
@@ -363,6 +373,7 @@ jobs:
             --build-arg 'vcpkg_url=${{ inputs.vcpkg_url }}' \
             --build-arg 'vcpkg_commit=${{ inputs.vcpkg_commit }}' \
             --build-arg 'extra_toolchains=${{ inputs.enable_rust  && format(';{0};rust;', inputs.extra_toolchains) || format(';{0};', inputs.extra_toolchains) }}' \
+            --build-arg 'cuda_version=${{ inputs.cuda_version }}' \
             -t duckdb/${{ matrix.duckdb_arch }} \
             ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
 
@@ -379,6 +390,8 @@ jobs:
           VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_target_triplet }}
           VCPKG_OVERLAY_TRIPLETS=/duckdb_build_dir/extensions-ci-tools/toolchains
           VCPKG_OVERLAY_PORTS=/duckdb_build_dir/extension-ci-tools/vcpkg_ports
+          CUDAARCHS=${{ inputs.cuda_archs }}
+          VCPKG_CUDA_VERSION=${{ inputs.cuda_version }}
           BUILD_SHELL=${{ inputs.build_duckdb_shell && '1' || '0' }}
           OPENSSL_ROOT_DIR=/duckdb_build_dir/build/${{ inputs.build_type }}/vcpkg_installed/${{ matrix.vcpkg_target_triplet }}
           OPENSSL_DIR=/duckdb_build_dir/build/${{ inputs.build_type }}/vcpkg_installed/${{ matrix.vcpkg_target_triplet }}

--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -118,3 +118,22 @@ RUN case "$extra_toolchains" in \
     yum install -y nasm SDL2-devel ffmpeg-devel \
   ;; \
 esac
+
+# Install CUDA toolkit (nvcc, dev headers, runtime)
+ARG cuda_version=13
+RUN case "$extra_toolchains" in \
+  *\;cuda\;*) \
+    yum install -y yum-utils && \
+    yum-config-manager --add-repo \
+      https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && \
+    yum install -y \
+      cuda-nvcc-${cuda_version}-* \
+      cuda-cudart-devel-${cuda_version}-* \
+      cuda-driver-devel-${cuda_version}-* \
+      cuda-nvml-devel-${cuda_version}-* \
+      libcurand-devel-${cuda_version}-* \
+      libnvjitlink-devel-${cuda_version}-* \
+      cuda-nvrtc-devel-${cuda_version}-* \
+  ;; \
+esac
+ENV PATH="/usr/local/cuda/bin:${PATH}"

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -120,3 +120,22 @@ RUN case "$extra_toolchains" in \
     yum install -y nasm SDL2-devel ffmpeg-devel \
   ;; \
 esac
+
+# Install CUDA toolkit (nvcc, dev headers, runtime)
+ARG cuda_version=13
+RUN case "$extra_toolchains" in \
+  *\;cuda\;*) \
+    yum install -y yum-utils && \
+    yum-config-manager --add-repo \
+      https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/cuda-rhel8.repo && \
+    yum install -y \
+      cuda-nvcc-${cuda_version}-* \
+      cuda-cudart-devel-${cuda_version}-* \
+      cuda-driver-devel-${cuda_version}-* \
+      cuda-nvml-devel-${cuda_version}-* \
+      libcurand-devel-${cuda_version}-* \
+      libnvjitlink-devel-${cuda_version}-* \
+      cuda-nvrtc-devel-${cuda_version}-* \
+  ;; \
+esac
+ENV PATH="/usr/local/cuda/bin:${PATH}"


### PR DESCRIPTION
## Summary
- Add `;cuda;` extra_toolchains option to Linux Docker images (amd64 + arm64) that installs the CUDA toolkit from NVIDIA's RHEL 8 repos
- Add `cuda_archs` and `cuda_version` workflow inputs so extensions can configure GPU architecture targets and CUDA version
- Packages installed: nvcc, cudart-devel, driver-devel, nvml-devel, curand-devel, nvjitlink-devel, nvrtc-devel
- CUDA version defaults to 13; toolkit is only installed when `;cuda;` is included in `extra_toolchains`, keeping existing builds unaffected

## Test plan
- [x] Verify existing builds without `;cuda;` in `extra_toolchains` are not affected
- [ ] Test with `extra_toolchains: "cuda"` to confirm CUDA packages install correctly in both amd64 and arm64 Docker images
- [ ] Test `cuda_archs` and `cuda_version` inputs propagate correctly as `CUDAARCHS` and `VCPKG_CUDA_VERSION` env vars

🤖 Created by Claude

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>