### PR TITLE
Make vcpkg overlay directories configurable

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -179,6 +179,16 @@ on:
         required: false
         type: string
         default: ""
+      # Override vcpkg overlay ports directory (relative to repo root, mounted at /duckdb_build_dir in Docker)
+      vcpkg_overlay_ports:
+        required: false
+        type: string
+        default: 'extension-ci-tools/vcpkg_ports'
+      # Override vcpkg overlay triplets directory
+      vcpkg_overlay_triplets:
+        required: false
+        type: string
+        default: 'extension-ci-tools/toolchains'
 
 env:
   VCPKG_BINARY_SOURCES: ${{inputs.vcpkg_binary_sources == '' && 'clear;http,https://vcpkg-cache.duckdb.org,read' || inputs.vcpkg_binary_sources }}
@@ -377,8 +387,8 @@ jobs:
           AWS_DEFAULT_REGION=${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
           AWS_REQUEST_CHECKSUM_CALCULATION=when_required
           VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_target_triplet }}
-          VCPKG_OVERLAY_TRIPLETS=/duckdb_build_dir/extensions-ci-tools/toolchains
-          VCPKG_OVERLAY_PORTS=/duckdb_build_dir/extension-ci-tools/vcpkg_ports
+          VCPKG_OVERLAY_TRIPLETS=/duckdb_build_dir/${{ inputs.vcpkg_overlay_triplets }}
+          VCPKG_OVERLAY_PORTS=/duckdb_build_dir/${{ inputs.vcpkg_overlay_ports }}
           BUILD_SHELL=${{ inputs.build_duckdb_shell && '1' || '0' }}
           OPENSSL_ROOT_DIR=/duckdb_build_dir/build/${{ inputs.build_type }}/vcpkg_installed/${{ matrix.vcpkg_target_triplet }}
           OPENSSL_DIR=/duckdb_build_dir/build/${{ inputs.build_type }}/vcpkg_installed/${{ matrix.vcpkg_target_triplet }}


### PR DESCRIPTION
## Summary
- Add `vcpkg_overlay_ports` and `vcpkg_overlay_triplets` workflow inputs to allow extensions to override the default vcpkg overlay directories
- Defaults match the current hardcoded paths, so existing builds are unaffected
- Also fixes a typo in the triplets path (`extensions-ci-tools` → `extension-ci-tools`)

## Test plan
- [x] Verify existing builds work without specifying the new inputs (defaults should match current behavior)
- [ ] Test overriding `vcpkg_overlay_ports` and `vcpkg_overlay_triplets` with custom paths

🤖 Created by Claude

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>