### PR TITLE
Replace cmake timestamp step with bash date

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -397,11 +397,8 @@ jobs:
           echo '${{ inputs.test_config }}'| jq -r '.test_env_variables // {} | to_entries | map("\(.key)=\(.value)")|.[]' >> docker_env.txt
 
       - name: Generate timestamp for Ccache entry
-        shell: cmake -P {0}
         id: ccache_timestamp
-        run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+        run: echo "timestamp=$(date -u '+%Y-%m-%d-%H;%M;%S')" >> "$GITHUB_OUTPUT"
 
       - name: Create Ccache directory
         run: |


### PR DESCRIPTION
## Summary
- Replace the `cmake -P` ccache timestamp step with a plain `date -u` command
- Output format is identical (`%Y-%m-%d-%H;%M;%S` UTC) — verified both produce the same string
- Avoids requiring cmake on the system PATH, which self-hosted runners may not have
- Replaces the deprecated `::set-output` command with `$GITHUB_OUTPUT`

## Test plan
- [x] Verify ccache timestamp output is unchanged (format: `2026-04-15-11;07;10`)
- [ ] Verify ccache restore/save still works correctly with the new step

🤖 Created by Claude

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>