### PR TITLE
Use dry-run mode for deploy when S3 secret key is missing

### DIFF
--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -133,7 +133,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY }}
           BUCKET_NAME: 'duckdb-extensions-nightly'
           DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.S3_DUCKDB_ORG_EXTENSION_SIGNING_PK }}
-          DUCKDB_DEPLOY_SCRIPT_MODE: for_real
+          DUCKDB_DEPLOY_SCRIPT_MODE: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY != '' && 'for_real' || '' }}
           PIP_BREAK_SYSTEM_PACKAGES: 1
         run: |
           pwd


### PR DESCRIPTION
This deployment [fails](https://github.com/duckdb/duckdb-azure/actions/runs/25170467732/job/73796606981) because `DUCKDB_DEPLOY_SCRIPT_MODE` is set to `for_real`:

```yaml
  env:
    AWS_ENDPOINT_URL: 
    AWS_ACCESS_KEY_ID: 
    AWS_SECRET_ACCESS_KEY: 
    BUCKET_NAME: duckdb-extensions-nightly
    DUCKDB_EXTENSION_SIGNING_PK: 
    DUCKDB_DEPLOY_SCRIPT_MODE: for_real
    PIP_BREAK_SYSTEM_PACKAGES: 1
```

but the AWS credentials are not defined (they come from `secrets`, and those are not accessible in a fork PR).

I would like to fix the deployment workflow of that repository by enabling dry-run mode automatically when the secret key value is empty.

Note that a dry-run with `rclone` and invalid/missing credentials should still fail because it's technically not able to perform the full PutObject operation when the bucket credentials are incorrect.
