### PR TITLE
Use duckdb's test runner

### DIFF
--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -18,7 +18,7 @@ all: release
 
 TEST_PATH=test/unittest
 
-DUCKDB_SRCDIR ?= ./duckdb/
+DUCKDB_SRCDIR ?= ./duckdb
 
 TESTS_BASE_DIRECTORY ?= test/
 

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -179,34 +179,27 @@ reldebug: ${EXTENSION_CONFIG_STEP}
 # Main tests
 test: test_release
 
-TEST_RELEASE_TARGET=test_release_internal
-TEST_DEBUG_TARGET=test_debug_internal
-TEST_RELDEBUG_TARGET=test_reldebug_internal
-
 # Disable testing outside docker: the unittester is currently dynamically linked by default
 ifeq ($(LINUX_CI_IN_DOCKER),0)
 	SKIP_TESTS=1
 endif
 
-ifeq ($(SKIP_TESTS),1)
-	TEST_RELEASE_TARGET=tests_skipped
-	TEST_DEBUG_TARGET=tests_skipped
-	TEST_RELDEBUG_TARGET=tests_skipped
-endif
+define RUN_TEST
+	@if [ "$(SKIP_TESTS)" = "1" ]; then \
+		echo "Tests are skipped in this run..."; \
+	else \
+		./build/$1/$(TEST_PATH) "$(TESTS_BASE_DIRECTORY)*"; \
+	fi
+endef
 
-test_release: $(TEST_RELEASE_TARGET)
-test_debug: $(TEST_DEBUG_TARGET)
-test_reldebug: $(TEST_RELDEBUG_TARGET)
+test_release:
+	$(call RUN_TEST,release)
 
-test_release_internal:
-	./build/release/$(TEST_PATH) "$(TESTS_BASE_DIRECTORY)*"
-test_debug_internal:
-	./build/debug/$(TEST_PATH) "$(TESTS_BASE_DIRECTORY)*"
-test_reldebug_internal:
-	./build/reldebug/$(TEST_PATH) "$(TESTS_BASE_DIRECTORY)*"
+test_debug:
+	$(call RUN_TEST,debug)
 
-tests_skipped:
-	@echo "Tests are skipped in this run..."
+test_reldebug:
+	$(call RUN_TEST,reldebug)
 
 # WASM config
 VCPKG_EMSDK_FLAGS=-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$(EMSDK)/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake
@@ -304,4 +297,3 @@ output_distribution_matrix:
 
 configure_ci:
 	@echo "configure_ci step is skipped for this extension build..."
-

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -16,12 +16,11 @@
 
 all: release
 
-TEST_PATH="/test/unittest"
-DUCKDB_PATH="/duckdb"
+TEST_PATH=test/unittest
 
-DUCKDB_SRCDIR ?= "./duckdb/"
+DUCKDB_SRCDIR ?= ./duckdb/
 
-TESTS_BASE_DIRECTORY = "test/"
+TESTS_BASE_DIRECTORY ?= test/
 
 ifeq (${SUBSET_EXTENSIONS_TESTS},complete)
 	TESTS_BASE_DIRECTORY=""

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -179,6 +179,12 @@ reldebug: ${EXTENSION_CONFIG_STEP}
 # Main tests
 test: test_release
 
+# Detect test runner. If missing, use the unittest binary directly.
+TEST_RUNNER ?= ${DUCKDB_SRCDIR}/scripts/ci/run_tests.py
+ifeq ($(shell which "$(TEST_RUNNER)" >/dev/null && echo yes),)
+	TEST_RUNNER :=
+endif
+
 # Disable testing outside docker: the unittester is currently dynamically linked by default
 ifeq ($(LINUX_CI_IN_DOCKER),0)
 	SKIP_TESTS=1
@@ -188,7 +194,7 @@ define RUN_TEST
 	@if [ "$(SKIP_TESTS)" = "1" ]; then \
 		echo "Tests are skipped in this run..."; \
 	else \
-		./build/$1/$(TEST_PATH) "$(TESTS_BASE_DIRECTORY)*"; \
+		$(TEST_RUNNER) ./build/$1/$(TEST_PATH) "$(TESTS_BASE_DIRECTORY)*"; \
 	fi
 endef
 


### PR DESCRIPTION
Use duckdb's test runner in extension CI pipelines. 

The test runner provides:
- parallelize tests to ~80% of CPUs.
- test batches to reduce process startup overhead (different from the older `run_tests_one_by_one.py`)
- retry failing test batches in CI (retries a single batch at most twice; in total, 4 batches are retried).

It's possible to disable the test runner using `TEST_RUNNER=""` or override the test runner to a specific command.

If the test runner cannot be found using `which`, it's omitted from the test command.