### PR TITLE
Force cl as C/C++ compiler on windows 2025

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -806,8 +806,8 @@ jobs:
       # Misc
       BUILD_SHELL: ${{ inputs.build_duckdb_shell && '1' || '0' }}
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-      CC: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 'gcc' || '' }}
-      CXX: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 'g++' || '' }}
+      CC: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 'gcc' || 'cl' }}
+      CXX: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 'g++' || 'cl' }}
       GEN: ninja
 
     steps:


### PR DESCRIPTION
Compiler usage difference between the two jobs:

- Passing job [73983861480](https://github.com/duckdb/duckdb-azure/actions/runs/25229912447/job/73983861480) (May 1) used MSVC:
    - `Check for working C compiler: .../MSVC/.../cl.exe`
    - `Check for working CXX compiler: .../MSVC/.../cl.exe`
- Failing job [75556521357](https://github.com/benfleis/duckdb-azure/actions/runs/25730592770/job/75556521357) (May 12) used MinGW:
    - `Check for working C compiler: C:/mingw64/bin/cc.exe`
    - `Check for working CXX compiler: C:/mingw64/bin/c++.exe`
    - link command runs `C:\mingw64\bin\c++.exe` and then fails on MSVC-style symbols from `azure-core.lib`.

This PR forces MSVC, and avoids falling back to MinGW.

This breakage is caused by GitHub's run image update of `windows-2025`:
<img width="786" height="368" alt="Screenshot 2026-05-12 at 14 08 27" src="https://github.com/user-attachments/assets/85f63294-f31f-4195-bef5-6bcbd697ec91" />
