### PR TITLE
Call visual studio 18's vcvars.bat

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -1001,11 +1001,19 @@ jobs:
         shell: cmd
         run: |
           if "%DUCKDB_PLATFORM_RTOOLS%" == "0" (
+            set "VCVARS_BAT="
             if "%DUCKDB_PLATFORM%" == "windows_amd64" (
-              call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+              set "VCVARS_BAT=vcvars64.bat"
             )
             if "%DUCKDB_PLATFORM%" == "windows_arm64" (
-              call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsarm64.bat"
+              set "VCVARS_BAT=vcvarsarm64.bat"
+            )
+            if defined VCVARS_BAT (
+              if exist "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\%VCVARS_BAT%" (
+                call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\%VCVARS_BAT%"
+              ) else (
+                call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\%VCVARS_BAT%"
+              )
             )
             REM Rename link.exe to link-git.exe to avoid conflicts with git supplied linker.
             mv "C:\Program Files\Git\usr\bin\link.exe" "C:\Program Files\Git\usr\bin\link-git.exe"

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -1000,6 +1000,7 @@ jobs:
           EXT_FLAGS: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         shell: cmd
         run: |
+          setlocal EnableDelayedExpansion
           if "%DUCKDB_PLATFORM_RTOOLS%" == "0" (
             set "VCVARS_BAT="
             if "%DUCKDB_PLATFORM%" == "windows_amd64" (
@@ -1009,10 +1010,10 @@ jobs:
               set "VCVARS_BAT=vcvarsarm64.bat"
             )
             if defined VCVARS_BAT (
-              if exist "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\%VCVARS_BAT%" (
-                call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\%VCVARS_BAT%"
+              if exist "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\!VCVARS_BAT!" (
+                call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\!VCVARS_BAT!"
               ) else (
-                call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\%VCVARS_BAT%"
+                call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\!VCVARS_BAT!"
               )
             )
             REM Rename link.exe to link-git.exe to avoid conflicts with git supplied linker.


### PR DESCRIPTION
Expected `vcvars*.bat` paths for `Visual Studio 18 2026`:

```
# windows-2025-vs2026
C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat

# windows-11-arm
C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsarm64.bat
```

See also https://github.com/duckdblabs/duckdb-internal/issues/9260.
