### PR TITLE
Add zic tzdata compiler dep on Alpine (1.5)

### DIFF
--- a/docker/linux_amd64_musl/Dockerfile
+++ b/docker/linux_amd64_musl/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3.22
 
 # Setup the basic necessities
 RUN apk update -q
-RUN apk add -qq ccache cmake git clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers libunwind-dev jq libtool
+RUN apk add -qq ccache cmake git clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers libunwind-dev jq libtool tzdata-utils
 RUN curl --no-progress-meter -LO https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/aws-cli-2.22.10-r0.apk
 RUN apk add --allow-untrusted aws-cli-2.22.10-r0.apk
 RUN curl --no-progress-meter -LO https://dl-cdn.alpinelinux.org/alpine/v3.23/community/x86_64/ninja-build-1.13.2-r0.apk

--- a/docker/linux_arm64_musl/Dockerfile
+++ b/docker/linux_arm64_musl/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3.22
 
 # Setup the basic necessities
 RUN apk update -q
-RUN apk add -qq ccache cmake git clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers libunwind-dev jq libtool
+RUN apk add -qq ccache cmake git clang19 gcc libssl3 wget bash zip gettext unzip build-base curl make libffi-dev zlib openssh autoconf linux-headers libunwind-dev jq libtool tzdata-utils
 RUN curl --no-progress-meter -LO https://dl-cdn.alpinelinux.org/alpine/v3.21/community/aarch64/aws-cli-2.22.10-r0.apk
 RUN apk add --allow-untrusted aws-cli-2.22.10-r0.apk
 RUN curl --no-progress-meter -LO https://dl-cdn.alpinelinux.org/alpine/v3.23/community/aarch64/ninja-build-1.13.2-r0.apk


### PR DESCRIPTION
This PR adds `tzdata-utils` dependency on Alpine to bring in the `zic` tzdata compiler that is used in the updated `libpq` for `duckdb-postgres`.