### PR TITLE
Disable EPEL 8 repo in manylinux_2_28 Dockerfiles (unblock all Linux extension builds)

### DIFF
--- a/docker/linux_amd64/Dockerfile
+++ b/docker/linux_amd64/Dockerfile
@@ -1,5 +1,8 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
+# Disable EPEL repo (mirrors are down since EPEL 8 retirement)
+RUN yum-config-manager --disable epel || true
+
 # Setup the basic necessities
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y curl zip unzip tar autoconf libtool

--- a/docker/linux_arm64/Dockerfile
+++ b/docker/linux_arm64/Dockerfile
@@ -1,5 +1,8 @@
 FROM quay.io/pypa/manylinux_2_28_aarch64
 
+# Disable EPEL repo (mirrors are down since EPEL 8 retirement)
+RUN yum-config-manager --disable epel || true
+
 # Setup the basic necessities
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y curl zip unzip tar autoconf libtool


### PR DESCRIPTION
Resolves #374.

## Problem

`quay.io/pypa/manylinux_2_28_{x86_64,aarch64}` (the base for both `docker/linux_amd64/Dockerfile` and `docker/linux_arm64/Dockerfile`) ships with the EPEL 8 repository enabled. EPEL 8 was retired by Fedora on **2024-05-31** ([life cycle docs](https://docs.fedoraproject.org/en-US/epel/epel-life-cycle/)) and the mirror endpoints now return HTTP 404 on `repodata/repomd.xml`. Because `yum` refreshes metadata for every enabled repo before processing a transaction, a single broken enabled repo aborts the whole transaction — so today every Linux extension build fails at the very first `yum` command (typically `yum groupinstall -y "Development Tools"`).

The downstream symptom is misleading ("Ninja / gcc / cmake not found"); the actual failure happens several layers earlier inside yum's metadata refresh.

Issue #374 has the full breakdown including the affected-version table (every active branch: `main`, `v1.5.2`, `v1.5.1`, `v1.5.0`, `v1.4.4`).

## Fix

Add one `RUN yum-config-manager --disable epel || true` at the top of each Dockerfile, immediately after the `FROM` line. Two files, six lines added, zero removed. Diff:

```diff
 FROM quay.io/pypa/manylinux_2_28_x86_64

+# Disable EPEL repo (mirrors are down since EPEL 8 retirement)
+RUN yum-config-manager --disable epel || true
+
 # Setup the basic necessities
 RUN yum groupinstall -y "Development Tools"
```

(identical change in `docker/linux_arm64/Dockerfile`)

### Why disable and not repoint

- **EPEL 8 mirrors are permanently 404.** Fedora archived the project in 2024-05; the bytes on `archives.fedoraproject.org` still exist but aren't security-patched and shouldn't be in a build hot path.
- **EPEL packages are only needed for the optional `multimedia` toolchain** (`ffmpeg-devel`, `SDL2-devel`, `nasm` — added in #314). All other `yum install` lines in these Dockerfiles pull from the base RHEL/CentOS streams that ship with manylinux_2_28 itself. So disabling EPEL has zero impact on the default build path.
- **`--disable` is non-destructive.** It just flips `enabled=0` in `/etc/yum.repos.d/epel.repo`. If a future toolchain genuinely needs EPEL it can re-enable on a per-install basis: `yum install --enablerepo=epel ...`. The repo file itself is untouched.
- **`|| true`** is defensive against base-image rebuilds that might drop `yum-config-manager`. The objective is "build doesn't fail" — if the repo file is already absent for any reason, that's fine, move on.

### Alternatives considered (rejected)

- **Bump base image to `manylinux_2_31`+** — cleanest long-term answer (newer Fedora base, no EPEL 8 dependency) but changes the glibc baseline from 2.28 to 2.31, which has potential ABI implications for the produced extension binaries. Orthogonal to unblocking today's builds; should probably happen eventually as a separate decision.
- **Repoint EPEL at `archives.fedoraproject.org`** — works but leaves a slow, unmaintained archive in the build path.

### Will this break the `multimedia` extra toolchain?

In its current state, the `multimedia` toolchain is **already broken** for everyone who isn't pinning a base image cached from before May 2024 — because `yum install -y nasm SDL2-devel ffmpeg-devel` against a 404-returning EPEL is a guaranteed failure today. This PR doesn't degrade `multimedia`; it just clarifies the current reality. A follow-up that wants to revive `multimedia` would need to either repoint EPEL at the archive (and accept the unmaintained-package risk) or bump to a newer manylinux base that ships those packages from a supported repo.

## Backport plan

Once this lands on `main`, the equivalent two-line addition needs to go to **`v1.5.2`**, **`v1.5.1`**, **`v1.5.0`**, and **`v1.4.4`** — all four are reachable refs in the wild (downstream extensions pin `_extension_distribution.yml@vX.Y.Z`). Happy to open four follow-up backport PRs once this one is approved, or to bundle them into a single PR per maintainer preference.

## Verification

I've been running the equivalent diff on a personal fork ([`lastrk/extension-ci-tools@fix-epel8`](https://github.com/lastrk/extension-ci-tools/tree/fix-epel8)) for the past ~6 weeks via the `override_ci_tools_repository` input. Latest successful run: 12-binary release across 3 DuckDB versions × 4 platforms at https://github.com/lastrk/thunderduck-duckdb-extension/releases/tag/ext4 (built 2026-05-13). All Linux jobs (`linux_amd64`, `linux_arm64`) for v1.4.4, v1.5.0, v1.5.1 went green with just this change — no other modifications needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)