### PR TITLE
Dont fail a rust build if build logs are missing

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -130,7 +130,7 @@ jobs:
       override_ref: main
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
-      duckdb_version: v1.5.1
+      duckdb_version: main
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64'
       extra_toolchains: 'rust'
       save_cache: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -521,11 +521,15 @@ jobs:
       - name: Print Rust logs
         if: ${{ inputs.rust_logs && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
         run: |
-          for filename in build/${{ inputs.build_type }}/rust/src/*/*build-*.log; do
-            echo Printing logs for file $filename
-            cat $filename;
-            echo Done printing logs for $filename
-          done
+          if find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0 | grep -qz .; then
+            while IFS= read -r -d '' filename; do
+              echo "Printing logs for file $filename"
+              cat "$filename"
+              echo "Done printing logs for $filename"
+            done < <(find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0)
+          else
+            echo "No Rust build logs found under build/${{ inputs.build_type }}/rust/src/"
+          fi
 
   macos:
     name: ${{ matrix.duckdb_arch }}
@@ -769,11 +773,15 @@ jobs:
       - name: Print Rust logs
         if: ${{ inputs.rust_logs && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
         run: |
-          for filename in build/${{ inputs.build_type }}/rust/src/*/*build-*.log; do
-            echo Printing logs for file $filename
-            cat $filename;
-            echo Done printing logs for $filename
-          done
+          if find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0 | grep -qz .; then
+            while IFS= read -r -d '' filename; do
+              echo "Printing logs for file $filename"
+              cat "$filename"
+              echo "Done printing logs for $filename"
+            done < <(find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0)
+          else
+            echo "No Rust build logs found under build/${{ inputs.build_type }}/rust/src/"
+          fi
 
   windows:
     name: ${{ matrix.duckdb_arch }}
@@ -1052,11 +1060,15 @@ jobs:
         if: ${{ inputs.rust_logs && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
         shell: bash
         run: |
-          for filename in build/${{ inputs.build_type }}/rust/src/*/*build-*.log; do
-            echo Printing logs for file $filename
-            cat $filename;
-            echo Done printing logs for $filename
-          done
+          if find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0 | grep -qz .; then
+            while IFS= read -r -d '' filename; do
+              echo "Printing logs for file $filename"
+              cat "$filename"
+              echo "Done printing logs for $filename"
+            done < <(find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0)
+          else
+            echo "No Rust build logs found under build/${{ inputs.build_type }}/rust/src/"
+          fi
 
       - name: Move rtools supplied zstd out of the way, so ccache can work
         if: (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw')
@@ -1246,8 +1258,12 @@ jobs:
         if: ${{ inputs.rust_logs && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
         shell: bash
         run: |
-          for filename in build/${{ inputs.build_type }}/rust/src/*/*build-*.log; do
-            echo Printing logs for file $filename
-            cat $filename;
-            echo Done printing logs for $filename
-          done
+          if find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0 | grep -qz .; then
+            while IFS= read -r -d '' filename; do
+              echo "Printing logs for file $filename"
+              cat "$filename"
+              echo "Done printing logs for $filename"
+            done < <(find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0)
+          else
+            echo "No Rust build logs found under build/${{ inputs.build_type }}/rust/src/"
+          fi


### PR DESCRIPTION
I [changed](https://github.com/duckdb/duckdb-delta/pull/311) log output settings for delta and that resulted in a CI failure:
```shell
$ for filename in build/release/rust/src/*/*build-*.log; do
    echo Printing logs for file $filename
    cat $filename;
    echo Done printing logs for $filename
  done
Printing logs for file build/release/rust/src/*/*build-*.log
cat: 'build/release/rust/src/*/*build-*.log': No such file or directory
Error: Process completed with exit code 1.
```
because the build log file is not kept for a successful build.

I added a placeholder log file in the delta repo to work around this CI error. (I'll remove this placeholder file in a later delta PR.)

This PR resolves the actual problem by only printing log files that exist and show a message if no log files are found (instead of a shell error).