### PR TITLE
Upgrade to windows-2025-vs2026 explicitly

### DIFF
--- a/config/distribution_matrix.json
+++ b/config/distribution_matrix.json
@@ -61,7 +61,7 @@
     "include": [
       {
         "duckdb_arch": "windows_amd64",
-        "runner": "windows-latest",
+        "runner": "windows-2025-vs2026",
         "vcpkg_target_triplet": "x64-windows-static-release",
         "vcpkg_host_triplet": "x64-windows-static-release",
         "run_in_reduced_ci_mode": true,
@@ -77,7 +77,7 @@
       },
       {
         "duckdb_arch": "windows_amd64_mingw",
-        "runner": "windows-latest",
+        "runner": "windows-2025-vs2026",
         "vcpkg_target_triplet": "x64-mingw-static",
         "vcpkg_host_triplet": "x64-mingw-static",
         "run_in_reduced_ci_mode": false,

--- a/scripts/extbuild/cmd/extbuild/matrix_test.go
+++ b/scripts/extbuild/cmd/extbuild/matrix_test.go
@@ -43,13 +43,13 @@ func TestComputePlatformMatrices(t *testing.T) {
     "include": [
       {
         "duckdb_arch": "windows_amd64",
-        "runner": "windows-latest",
+        "runner": "windows-2025-vs2026",
         "run_in_reduced_ci_mode": true,
         "opt_in": false
       },
       {
         "duckdb_arch": "windows_amd64_mingw",
-        "runner": "windows-latest",
+        "runner": "windows-2025-vs2026",
         "run_in_reduced_ci_mode": true,
         "opt_in": false
       },
@@ -221,7 +221,7 @@ func TestMatrixSubcommandWritesOutputFile(t *testing.T) {
   },
   "windows": {
     "include": [
-      {"duckdb_arch":"windows_amd64","runner":"windows-latest","run_in_reduced_ci_mode":true,"opt_in":false}
+      {"duckdb_arch":"windows_amd64","runner":"windows-2025-vs2026","run_in_reduced_ci_mode":true,"opt_in":false}
     ]
   }
 }`
@@ -290,7 +290,7 @@ func TestMatrixSubcommandPreservesRunnerWhenNotOverridden(t *testing.T) {
 	inputJSON := `{
   "windows": {
     "include": [
-      {"duckdb_arch":"windows_amd64","runner":"windows-latest","run_in_reduced_ci_mode":true,"opt_in":false}
+      {"duckdb_arch":"windows_amd64","runner":"windows-2025-vs2026","run_in_reduced_ci_mode":true,"opt_in":false}
     ]
   }
 }`
@@ -310,7 +310,7 @@ func TestMatrixSubcommandPreservesRunnerWhenNotOverridden(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(strings.TrimPrefix(line, "windows_matrix=")), &matrix))
 	require.Len(t, matrix.Include, 1)
 	assert.Equal(t, "windows_amd64", matrix.Include[0].DuckDBArch)
-	assert.Equal(t, "windows-latest", matrix.Include[0].Runner)
+	assert.Equal(t, "windows-2025-vs2026", matrix.Include[0].Runner)
 }
 
 func TestMatrixSubcommandWithoutArgs(t *testing.T) {
@@ -335,7 +335,7 @@ func TestMatrixSubcommandDeployMode(t *testing.T) {
   },
   "windows": {
     "include": [
-      {"duckdb_arch":"windows_amd64","runner":"windows-latest","run_in_reduced_ci_mode":true,"opt_in":false}
+      {"duckdb_arch":"windows_amd64","runner":"windows-2025-vs2026","run_in_reduced_ci_mode":true,"opt_in":false}
     ]
   }
 }`


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9260.

`Extension template / windows_amd64` [uses](https://github.com/duckdb/extension-ci-tools/actions/runs/26104076919/job/76765563914?pr=377) vs2026 now:
```
Run setlocal EnableDelayedExpansion
**********************************************************************
** Visual Studio 2026 Developer Command Prompt v18.5.2
** Copyright (c) 2026 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x64'
```

`Extension tempplate / windows_amd64_mingw` also [uses](https://github.com/duckdb/extension-ci-tools/actions/runs/26104076919/job/76765563891?pr=377#step:1:16) the vs2026 image now: 
```
Runner Image
  Image: windows-2025-vs2026
  Version: 20260510.103.1
  Included Software: https://github.com/actions/runner-images/blob/win25-vs2026/20260510.103/images/windows/Windows2025-VS2026-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/win25-vs2026%2F20260510.103
```

See also https://github.com/duckdb/duckdb/pull/22763.

Earlier merged PRS:
- https://github.com/duckdb/extension-ci-tools/pull/367
- https://github.com/duckdb/extension-ci-tools/pull/368
- https://github.com/duckdb/extension-ci-tools/pull/370