### PR TITLE
Fix CI for DuckDB Community Extensions for WASM Builds

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -1160,7 +1160,7 @@ jobs:
         run: |
           DUCKDB_TAG=${{ inputs.duckdb_tag }} make set_duckdb_tag
 
-      - uses: mymindstorm/setup-emsdk@v13
+      - uses: emscripten-core/setup-emsdk@v13
         with:
           version: 3.1.71
 


### PR DESCRIPTION
Hi everyone,

The WASM builds for DuckDB community extensions are currently failing CI.

The problem is that the CI file looks for `mymindstorm/setup-emsdk` which was moved to `emscripten-core/setup-emsdk`. 

It looks like the MotherDuck folks ran into the same issue: https://github.com/emscripten-core/setup-emsdk/issues/61

This pull request renames the repo in the CI file which should fix the issue.