### PR TITLE
Replace mymindstorm/setup-emsdk with emscripten-core/setup-emsdk in v1.5

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -1119,7 +1119,7 @@ jobs:
         run: |
           DUCKDB_TAG=${{ inputs.duckdb_tag }} make set_duckdb_tag
 
-      - uses: mymindstorm/setup-emsdk@v13
+      - uses: emscripten-core/setup-emsdk@v13
         with:
           version: 3.1.71
 


### PR DESCRIPTION
The emscripten action has been [renamed](https://github.com/emscripten-core/setup-emsdk/issues/61).

Namespace runners have action caching so that could be the reason why we're not seeing similar errors in CI.

Related PR: https://github.com/duckdb/extension-ci-tools/pull/381.

See also:
- https://github.com/duckdb/duckdb/pull/23043
- https://github.com/duckdb/duckdb/pull/23045