### PR TITLE
Enable test retry and configure fail-fast with reduced_ci_mode

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -253,6 +253,7 @@ jobs:
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.linux_matrix != '{}' && needs.generate_matrix.outputs.linux_matrix != '' }}
     strategy:
+      fail-fast: ${{ inputs.reduced_ci_mode != 'disabled' }}
       matrix: ${{fromJson(needs.generate_matrix.outputs.linux_matrix)}}
     env:
       # VCPKG config
@@ -545,8 +546,9 @@ jobs:
       needs.generate_matrix.outputs.osx_matrix != '{}' &&
       needs.generate_matrix.outputs.osx_matrix != '' &&
       needs.generate_matrix.result == 'success' &&
-      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
+      (inputs.reduced_ci_mode == 'disabled' || needs.linux.result == 'success' || needs.linux.result == 'skipped')
     strategy:
+      fail-fast: ${{ inputs.reduced_ci_mode != 'disabled' }}
       matrix: ${{fromJson(needs.generate_matrix.outputs.osx_matrix)}}
     env:
       # VCPKG config
@@ -797,8 +799,9 @@ jobs:
       needs.generate_matrix.outputs.windows_matrix != '{}' &&
       needs.generate_matrix.outputs.windows_matrix != '' &&
       needs.generate_matrix.result == 'success' &&
-      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
+      (inputs.reduced_ci_mode == 'disabled' || needs.linux.result == 'success' || needs.linux.result == 'skipped')
     strategy:
+      fail-fast: ${{ inputs.reduced_ci_mode != 'disabled' }}
       matrix: ${{fromJson(needs.generate_matrix.outputs.windows_matrix)}}
     env:
       # VCPKG config
@@ -1090,8 +1093,9 @@ jobs:
       needs.generate_matrix.outputs.wasm_matrix != '{}' &&
       needs.generate_matrix.outputs.wasm_matrix != '' &&
       needs.generate_matrix.result == 'success' &&
-      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
+      (inputs.reduced_ci_mode == 'disabled' || needs.linux.result == 'success' || needs.linux.result == 'skipped')
     strategy:
+      fail-fast: ${{ inputs.reduced_ci_mode != 'disabled' }}
       matrix: ${{fromJson(needs.generate_matrix.outputs.wasm_matrix)}}
     env:
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -413,6 +413,8 @@ jobs:
           EXTENSION_NAME=${{ inputs.extension_name }}
           EXTENSION_CANONICAL=${{ inputs.extension_canonical }}
           LINUX_CI_IN_DOCKER=1
+          GITHUB_ACTIONS=true
+          CI=true
           CCACHE_MAXSIZE=1G
           CCACHE_NOCOMPRESS=1
           SUBSET_EXTENSIONS_TESTS=${{ inputs.extensions_test_selection }}


### PR DESCRIPTION
- Propagate `CI` and `GITHUB_ACTIONS` correctly inside build container.
  - This allows the test runner to detect CI and thus enable test retries.
- Use `strategy.fail-fast` only if `reduced_ci_mode` is `auto`/`enabled`.
  - It's not useful to cancel all remaining extension CI jobs on duckdb main if one CI job failed because canceling those can hide errors in other platforms/archs.
  - For the nightly CI run, `reduced_ci_mode` [is](https://github.com/duckdb/duckdb/actions/runs/26924333346/job/79469790610#step:1:115) `disabled` and it should not cancel the remaining CI jobs.