### PR TITLE
fix(extbuild): logger race in parallel tests

### DIFF
--- a/scripts/extbuild/cmd/extbuild/logging.go
+++ b/scripts/extbuild/cmd/extbuild/logging.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -23,6 +25,19 @@ func newLogger(w io.Writer) *slog.Logger {
 		writer: w,
 		level:  slog.LevelInfo,
 	})
+}
+
+type loggerContextKey struct{}
+
+func attachCommandLogger(cmd *cobra.Command) {
+	cmd.SetContext(context.WithValue(cmd.Context(), loggerContextKey{}, newLogger(cmd.ErrOrStderr())))
+}
+
+func commandLogger(cmd *cobra.Command) *slog.Logger {
+	if logger, ok := cmd.Context().Value(loggerContextKey{}).(*slog.Logger); ok {
+		return logger
+	}
+	return slog.Default()
 }
 
 func colorizeLevel(level slog.Level) string {

--- a/scripts/extbuild/cmd/extbuild/matrix.go
+++ b/scripts/extbuild/cmd/extbuild/matrix.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 
 	"github.com/duckdb/extension-ci-tools/internal/distmatrix"
@@ -27,16 +26,16 @@ func newMatrixCommand() *cobra.Command {
 		Short: "Compute distribution matrices and emit GitHub output lines",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if eventPath := os.Getenv("GITHUB_EVENT_PATH"); eventPath != "" {
-				slog.Info("Using GitHub event payload file", "event_path", eventPath)
+				commandLogger(cmd).Info("Using GitHub event payload file", "event_path", eventPath)
 			} else {
-				slog.Info("GITHUB_EVENT_PATH is not set so event type is unknown")
+				commandLogger(cmd).Info("GITHUB_EVENT_PATH is not set so event type is unknown")
 			}
 
 			eventType, err := detectGitHubEventTypeFromEnv()
 			if err != nil {
 				return fmt.Errorf("detect GitHub event type: %w", err)
 			}
-			slog.Info("Detected GitHub event type", "event_type", eventType)
+			commandLogger(cmd).Info("Detected GitHub event type", "event_type", eventType)
 
 			reducedCIMode, err := distmatrix.ParseReducedCIMode(reducedCIModeRaw)
 			if err != nil {
@@ -44,7 +43,7 @@ func newMatrixCommand() *cobra.Command {
 			}
 			if eventType == githubEventPullRequest && reducedCIMode == distmatrix.ReducedCIAuto {
 				reducedCIMode = distmatrix.ReducedCIEnabled
-				slog.Info("Enabled reduced CI mode for pull_request event when mode is auto")
+				commandLogger(cmd).Info("Enabled reduced CI mode for pull_request event when mode is auto")
 			}
 
 			data, err := os.ReadFile(inputPath)

--- a/scripts/extbuild/cmd/extbuild/root.go
+++ b/scripts/extbuild/cmd/extbuild/root.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"log/slog"
-
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +9,7 @@ func newRootCommand() *cobra.Command {
 		Use:   "extbuild",
 		Short: "DuckDB extension CI helper CLI",
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-			slog.SetDefault(newLogger(cmd.ErrOrStderr()))
+			attachCommandLogger(cmd)
 		},
 	}
 	cmd.AddCommand(newMatrixCommand())


### PR DESCRIPTION
Store the pretty logger on each command context instead of mutating `slog.Default()`, so parallel matrix tests no longer share stderr writers.

We were seeing intermittent failures in the duckdb project (see https://github.com/duckdb/duckdb-iceberg/actions/runs/28115665045/job/83254454832?pr=1034#logs)