### PR TITLE
Pin macos version for extension_distribution workflow

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -500,7 +500,7 @@ jobs:
 
   macos:
     name: MacOS
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     needs:
       - generate_matrix
       - linux

--- a/config/distribution_matrix.json
+++ b/config/distribution_matrix.json
@@ -39,6 +39,7 @@
     "include": [
       {
         "duckdb_arch": "osx_amd64",
+        "runner": "macos-15",
         "osx_build_arch": "x86_64",
         "vcpkg_target_triplet": "x64-osx-release",
         "vcpkg_host_triplet": "arm64-osx-release",
@@ -47,6 +48,7 @@
       },
       {
         "duckdb_arch": "osx_arm64",
+        "runner": "macos-15",
         "osx_build_arch": "arm64",
         "vcpkg_target_triplet": "arm64-osx-release",
         "vcpkg_host_triplet": "arm64-osx-release",


### PR DESCRIPTION
Github is performing a rollout of upgrading the "macos-latest" label from MacOS 15 -> MacOS 26. More info available here: https://github.com/actions/runner-images/issues/14167

This seems to be causing the issues with the "InvokeCI" workflow on duckdb/duckdb variegata branch not being able to build some extensions for MacOS. An example of this can be seen comparing build [#1009](https://github.com/duckdb/duckdb/actions/runs/27957670696/job/82759524212) with [#1010](https://github.com/duckdb/duckdb/actions/runs/28068288097/job/83109414060). Under "Set up job"->"Runner Image", the image differs from macos 15 -> macos 26. 

Pinning the macos runner image to macos-15 should improve reproducibility for the variegata branch and mitigate similar issues in the future. 
If you would rather fix underlying problems and migrate to macos-26 directly that is also an option, but considering the relatively short lifespan of the variegata release this could be a quick solution. 