### PR TITLE
Propagate extension builds correctly when DUCKDB_NEW_EXTENSION_BUILD is set

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -38,7 +38,7 @@ jobs:
       extension_name: capi_quack
       override_repository: duckdb/extension-template-c
       override_ref: main
-      duckdb_version: v1.5.1
+      duckdb_version: main
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3;unixodbc'
@@ -54,7 +54,7 @@ jobs:
       artifact_postfix: custom-runners
       override_repository: duckdb/extension-template-c
       override_ref: main
-      duckdb_version: v1.5.1
+      duckdb_version: main
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       runners: '{"linux_x64":"ubuntu-latest"}'
@@ -74,7 +74,7 @@ jobs:
       extension_name: quack
       override_repository: duckdb/extension-template
       override_ref: main
-      duckdb_version: v1.5.1
+      duckdb_version: main
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp;go;python3;downgraded_aws_cli;'
@@ -95,7 +95,7 @@ jobs:
     uses: ./.github/workflows/_extension_deploy.yml
     with:
       extension_name: quack
-      duckdb_version: v1.5.1
+      duckdb_version: main
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       deploy_script: /bin/true
@@ -111,7 +111,7 @@ jobs:
       extension_name: rusty_quack
       override_repository: duckdb/extension-template-rs
       override_ref: main
-      duckdb_version: v1.5.1
+      duckdb_version: main
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'rust;python3'

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -38,7 +38,7 @@ jobs:
       extension_name: capi_quack
       override_repository: duckdb/extension-template-c
       override_ref: main
-      duckdb_version: main
+      duckdb_version: v1.5.4
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3;unixodbc'
@@ -54,7 +54,7 @@ jobs:
       artifact_postfix: custom-runners
       override_repository: duckdb/extension-template-c
       override_ref: main
-      duckdb_version: main
+      duckdb_version: v1.5.4
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       runners: '{"linux_x64":"ubuntu-latest"}'
@@ -74,7 +74,7 @@ jobs:
       extension_name: quack
       override_repository: duckdb/extension-template
       override_ref: main
-      duckdb_version: main
+      duckdb_version: v1.5.4
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp;go;python3;downgraded_aws_cli;'
@@ -95,7 +95,7 @@ jobs:
     uses: ./.github/workflows/_extension_deploy.yml
     with:
       extension_name: quack
-      duckdb_version: main
+      duckdb_version: v1.5.4
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       deploy_script: /bin/true
@@ -111,7 +111,7 @@ jobs:
       extension_name: rusty_quack
       override_repository: duckdb/extension-template-rs
       override_ref: main
-      duckdb_version: main
+      duckdb_version: v1.5.4
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'rust;python3'

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -12,7 +12,7 @@
 #	DEFAULT_TEST_EXTENSION_DEPS : `;`-separated list of extensions that are built in `default` and `full` mode
 #	FULL_TEST_EXTENSION_DEPS    : `;`-separated list of extensions that are built in `full` mode
 
-.PHONY: all clean clean-python clangd format debug release pull update wasm_mvp wasm_eh wasm_threads test test_release test_debug test_reldebug test_release_internal test_debug_internal test_reldebug_internal set_duckdb_version set_duckdb_tag  output_distribution_matrix
+.PHONY: all clean clean-python clangd format debug release pull update wasm_mvp wasm_eh wasm_threads test test_release test_debug test_reldebug test_release_internal test_debug_internal test_reldebug_internal set_duckdb_version set_duckdb_tag  output_distribution_matrix sync_oot_extensions
 
 all: release
 
@@ -81,7 +81,13 @@ ifneq ("${VCPKG_TOOLCHAIN_PATH}", "")
 endif
 
 # Add the extension config step which ensures the vcpkg dependencies of all extensions get merged properly
-ifeq (${USE_MERGED_VCPKG_MANIFEST}, 1)
+ifdef DUCKDB_NEW_EXTENSION_BUILD
+	# New-style build: out-of-tree extensions are pre-cloned into duckdb/extension/external
+	# and their merged vcpkg manifest (including this extension's own vcpkg.json) is written
+	# to build/ before cmake configures, so vcpkg picks it up at project() time.
+	EXTENSION_CONFIG_STEP= sync_oot_extensions
+	VCPKG_MANIFEST_FLAGS:=-DVCPKG_MANIFEST_DIR='${PROJ_DIR}build'
+else ifeq (${USE_MERGED_VCPKG_MANIFEST}, 1)
 	EXTENSION_CONFIG_STEP= build/extension_configuration/vcpkg.json
 	EXTENSION_CONFIG_STEP_WASM=extension_configuration_wasm
 	VCPKG_MANIFEST_FLAGS:=-DVCPKG_MANIFEST_DIR='${PROJ_DIR}build/extension_configuration'
@@ -263,6 +269,12 @@ EXTENSION_CONFIG_TARGET?=extension_configuration_default
 extension_configuration: build/extension_configuration/vcpkg.json
 
 build/extension_configuration/vcpkg.json: ${EXTENSION_CONFIG_TARGET}
+
+# New-style out-of-tree extension sync: clone/patch out-of-tree extensions into
+# duckdb/extension/external and write the merged vcpkg manifest into build/.
+sync_oot_extensions:
+	mkdir -p '${PROJ_DIR}build'
+	python3 $(DUCKDB_SRCDIR)/scripts/sync_out_of_tree_extensions.py --extension-configs '$(EXTENSION_CONFIGS)' --output-dir '${PROJ_DIR}build'
 
 #### Misc
 format-check:


### PR DESCRIPTION
Together with https://github.com/duckdb/duckdb/pull/23862 fixes up extension builds when `DUCKDB_NEW_EXTENSION_BUILD` is set.