### PR TITLE
tidy-check: lint all of src/, not only its subdirectories

### DIFF
--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -164,6 +164,10 @@ endif
 ifneq ($(TIDY_CHECKS),)
         TIDY_PERFORM_CHECKS := '-checks=${TIDY_CHECKS}'
 endif
+# Regex selecting which files clang-tidy lints (and reports headers for). The
+# default covers everything under src/. Overridable so extensions with a lint
+# backlog can narrow it while they clean up.
+TIDY_SRC_REGEX ?= $(PROJ_DIR)src/
 
 clangd: ${EXTENSION_CONFIG_STEP}
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_DEBUG_FLAGS) $(VCPKG_MANIFEST_FLAGS) -DCMAKE_BUILD_TYPE=Debug -S $(DUCKDB_SRCDIR) -B .cache/clangd/debug
@@ -292,7 +296,7 @@ tidy-check:
 	mkdir -p ./build/tidy
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_DEBUG_FLAGS) -DDISABLE_UNITY=1 -DCLANG_TIDY=1 -S $(DUCKDB_SRCDIR) -B build/tidy
 	cp duckdb/.clang-tidy build/tidy/.clang-tidy
-	cd build/tidy && python3 ../../duckdb/scripts/run-clang-tidy.py '$(PROJ_DIR)src/.*/' -header-filter '$(PROJ_DIR)src/.*/' -quiet ${TIDY_THREAD_PARAMETER} ${TIDY_BINARY_PARAMETER} ${TIDY_PERFORM_CHECKS}
+	cd build/tidy && python3 ../../duckdb/scripts/run-clang-tidy.py '$(TIDY_SRC_REGEX)' -header-filter '$(TIDY_SRC_REGEX)' -quiet ${TIDY_THREAD_PARAMETER} ${TIDY_BINARY_PARAMETER} ${TIDY_PERFORM_CHECKS}
 
 update:
 	git submodule update --remote --merge


### PR DESCRIPTION
The `tidy-check` target passes the file regex `'$(PROJ_DIR)src/.*/'` to `run-clang-tidy.py`. That pattern requires a second path separator after `src/`, so it only matches files in subdirectories of `src/` - translation units directly in `src/` are never linted.

This includes the layout `duckdb/extension-template` ships (`src/<name>_extension.cpp`), so template-derived extensions get no tidy coverage of their main source files. We hit this in `iqea-ai/duckdb-snowflake`: 12 of our 18 translation units sit directly in `src/` and had never been linted; widening the pattern surfaced a small backlog we cleaned up in [iqea-ai/duckdb-snowflake#62](https://github.com/iqea-ai/duckdb-snowflake/pull/62).

This PR defaults the pattern to `'$(PROJ_DIR)src/'` through a new overridable `TIDY_SRC_REGEX` variable. The variable is the migration path: an extension whose newly covered files carry a lint backlog can set `TIDY_SRC_REGEX` to the old pattern (or any narrower one) in its own Makefile while it cleans up, instead of its tidy job going red on the version bump.
