### PR TITLE
Reduce CI steps and use larger ccache size

### DIFF
--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -73,8 +73,14 @@ jobs:
       duckdb_version: v1.5.4
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
-      runners: '{"linux_x64":"ubuntu-latest"}'
-      exclude_archs: 'linux_arm64;osx_amd64;osx_arm64;wasm_eh;wasm_mvp;wasm_threads;windows_amd64_mingw;windows_amd64'
+      runners: >-
+        ${{
+          github.repository_owner == 'duckdb'
+          && '{"linux_x64":"ubuntu-latest","osx_arm64":"namespace-profile-macos-arm64"}'
+          || '{"linux_x64":"ubuntu-latest","osx_arm64":"macos-14"}'
+        }}
+      exclude_archs: 'linux_arm64;osx_amd64;wasm_eh;wasm_mvp;wasm_threads;windows_amd64_mingw;windows_amd64'
+      reduced_ci_mode: disabled
       save_cache: false
       post_build_command: |
         echo "matrix runner: $MATRIX_RUNNER"

--- a/.github/workflows/TestCITools.yml
+++ b/.github/workflows/TestCITools.yml
@@ -19,6 +19,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  phase-runner-tests:
+    name: Distribution phase runner tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Run unit tests
+        run: python -m unittest discover -s scripts -p 'test_*.py' -v
+
   code-quality:
     name: Code Quality
     uses: ./.github/workflows/_extension_code_quality.yml

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -202,7 +202,35 @@ on:
 
 env:
   VCPKG_BINARY_SOURCES: ${{inputs.vcpkg_binary_sources == '' && 'clear;http,https://vcpkg-cache.duckdb.org,read' || inputs.vcpkg_binary_sources }}
+  USE_MERGED_VCPKG_MANIFEST: ${{ inputs.use_merged_vcpkg_manifest }}
   USE_DEFAULT_RUNNERS: ${{ inputs.runners == '{}' }}
+  CI_EXTENSION_NAME: ${{ inputs.extension_name }}
+  CI_EXTENSION_CANONICAL: ${{ inputs.extension_canonical }}
+  CI_DUCKDB_VERSION: ${{ inputs.duckdb_version }}
+  CI_DUCKDB_GIT_REPOSITORY: ${{ inputs.override_duckdb_repository }}
+  CI_EXTENSION_TAG: ${{ inputs.extension_tag }}
+  CI_DUCKDB_TAG: ${{ inputs.duckdb_tag }}
+  CI_EXTRA_TOOLCHAINS: ${{ inputs.enable_rust && format('{0};rust;', inputs.extra_toolchains) || inputs.extra_toolchains }}
+  CI_HAS_RUST: ${{ inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;') }}
+  CI_EXTRA_EXTENSION_CONFIG: ${{ inputs.extra_extension_config }}
+  CI_VCPKG_EXTRA_DEPENDENCIES: ${{ inputs.vcpkg_extra_dependencies }}
+  CI_VCPKG_URL: ${{ inputs.vcpkg_url }}
+  CI_VCPKG_COMMIT: ${{ inputs.vcpkg_commit }}
+  CI_VCPKG_OVERLAY_PORTS: ${{ inputs.vcpkg_overlay_ports }}
+  CI_VCPKG_OVERLAY_TRIPLETS: ${{ inputs.vcpkg_overlay_triplets }}
+  CI_CUDA_ARCHS: ${{ inputs.cuda_archs }}
+  CI_CUDA_VERSION: ${{ inputs.cuda_version }}
+  CI_BUILD_DUCKDB_SHELL: ${{ inputs.build_duckdb_shell }}
+  CI_BUILD_TYPE: ${{ inputs.build_type }}
+  CI_POST_BUILD_COMMAND: ${{ inputs.post_build_command }}
+  CI_TEST_CONFIG: ${{ inputs.test_config }}
+  CI_SKIP_TESTS: ${{ inputs.skip_tests }}
+  CI_EXTENSIONS_TEST_SELECTION: ${{ inputs.extensions_test_selection }}
+  CI_UPLOAD_ALL_EXTENSIONS: ${{ inputs.upload_all_extensions }}
+  CI_ARTIFACT_POSTFIX: ${{ inputs.artifact_postfix }}
+  CI_RUST_LOGS: ${{ inputs.rust_logs }}
+  CI_RUN_DISK_CLEAN_STEP: ${{ inputs.run_disk_clean_step }}
+  CI_USE_DEFAULT_RUNNERS: ${{ inputs.runners == '{}' }}
 
 jobs:
   generate_matrix:
@@ -254,294 +282,97 @@ jobs:
     if: ${{ needs.generate_matrix.outputs.linux_matrix != '{}' && needs.generate_matrix.outputs.linux_matrix != '' }}
     strategy:
       fail-fast: ${{ inputs.reduced_ci_mode != 'disabled' }}
-      matrix: ${{fromJson(needs.generate_matrix.outputs.linux_matrix)}}
+      matrix: ${{ fromJson(needs.generate_matrix.outputs.linux_matrix) }}
     env:
-      # VCPKG config
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
-      # VCPKG caching
       AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
       AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
       AWS_REQUEST_CHECKSUM_CALCULATION: when_required
-      # Misc
       GEN: ninja
       BUILD_SHELL: ${{ inputs.build_duckdb_shell && '1' || '0' }}
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      CI_PLATFORM: linux
+      CI_MATRIX_RUNNER: ${{ matrix.runner }}
 
     steps:
-      - name: Free disk space 1
-        uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3.2.2
-        continue-on-error: true
-        if: ${{ inputs.run_disk_clean_step && env.USE_DEFAULT_RUNNERS == 'true' }}
-        with:
-#          remove_android: true # ~9.5GB in #52s
-#          remove_dotnet: true
-          remove_haskell: true # ~6.5GB in ~3s
-          remove_tool_cache: true # ~4.8GB in ~17s
-#          remove_swap: true
-#          remove_packages_one_command: true # ~7.5 GB in ~94s
-          remove_folders: "/usr/local/share/powershell /usr/share/swift" # ~ 4GB in ?s
-          testing: false
-
-      - name: Free disk space 2
-        continue-on-error: true
-        if: ${{ inputs.run_disk_clean_step && env.USE_DEFAULT_RUNNERS == 'true' }}
-        run: |
-          docker images -a -q > package.list
-          if [ -s package.list ]; then
-              echo "To be deleted"
-              cat package.list
-              echo "---"
-              docker rmi $(cat package.list)
-          fi
-          rm package.list
-
-      - name: Restart docker to run on /mnt
-        if: ${{ env.USE_DEFAULT_RUNNERS == 'true' }}
-        run: |
-          sudo systemctl stop docker
-
-      - name: Configure Docker with custom data directory
-        if: ${{ env.USE_DEFAULT_RUNNERS == 'true' }}
-        run: |
-          sudo mkdir -p /mnt/docker-data
-          echo '{ "data-root": "/mnt/docker-data" }' | sudo tee /etc/docker/daemon.json
-
-      - name: Start Docker with updated storage path
-        if: ${{ env.USE_DEFAULT_RUNNERS == 'true' }}
-        run: sudo systemctl start docker
-
-      - name: Verify Docker storage path
-        if: ${{ env.USE_DEFAULT_RUNNERS == 'true' }}
-        run: docker info | grep "Docker Root Dir"
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout override repository
-        if: ${{inputs.override_repository != ''}}
-        with:
-          repository: ${{ inputs.override_repository }}
-          ref: ${{ inputs.override_ref }}
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout current repository
-        if: ${{inputs.override_repository == ''}}
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout Extension CI tools
-        with:
-          path: 'extension-ci-tools'
-          ref: ${{ inputs.ci_tools_version }}
-          repository: ${{ inputs.override_ci_tools_repository }}
-
-      - name: Fetch override repository
-        if: ${{inputs.override_duckdb_repository != ''}}
-        run: |
-          DUCKDB_GIT_REPOSITORY=${{ inputs.override_duckdb_repository }} make set_duckdb_repository
-
-      - name: Set DuckDB to ref of calling workflow
-        if: ${{inputs.set_caller_as_duckdb}}
+      - name: Checkout / Extension repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          path: 'duckdb'
+          repository: ${{ inputs.override_repository != '' && inputs.override_repository || github.repository }}
+          ref: ${{ inputs.override_repository != '' && inputs.override_ref || '' }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Checkout / Extension CI tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: extension-ci-tools
+          ref: ${{ inputs.ci_tools_version }}
+          repository: ${{ inputs.override_ci_tools_repository }}
+          fetch-depth: 0
+
+      - name: Checkout / DuckDB from calling workflow
+        if: ${{ inputs.set_caller_as_duckdb }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: duckdb
           fetch-tags: true
           fetch-depth: 0
 
-      - name: Checkout DuckDB to version
-        if: ${{ inputs.duckdb_version != '' }}
-        run: |
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
-
-      - name: Tag extension
-        if: ${{inputs.extension_tag != ''}}
-        run: |
-          git tag ${{ inputs.extension_tag }}
-
-      - name: Tag DuckDB extension
-        if: ${{inputs.duckdb_tag != ''}}
-        run: |
-          DUCKDB_TAG=${{ inputs.duckdb_tag }} make set_duckdb_tag
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout Extension CI tools
+      - name: Setup / Free disk space
+        if: ${{ inputs.run_disk_clean_step && env.USE_DEFAULT_RUNNERS == 'true' }}
+        uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3.2.2
+        continue-on-error: true
         with:
-          path: 'extension-ci-tools'
-          ref: ${{ inputs.ci_tools_version }}
-          repository: ${{ inputs.override_ci_tools_repository }}
-          fetch-depth: 0
+          remove_haskell: true
+          remove_tool_cache: true
+          remove_folders: "/usr/local/share/powershell /usr/share/swift"
+          testing: false
 
-      - name: Build Docker image
-        shell: bash
-        run: |
-          docker build \
-            --build-arg 'vcpkg_url=${{ inputs.vcpkg_url }}' \
-            --build-arg 'vcpkg_commit=${{ inputs.vcpkg_commit }}' \
-            --build-arg 'extra_toolchains=${{ inputs.enable_rust  && format(';{0};rust;', inputs.extra_toolchains) || format(';{0};', inputs.extra_toolchains) }}' \
-            --build-arg 'cuda_version=${{ inputs.cuda_version }}' \
-            -t duckdb/${{ matrix.duckdb_arch }} \
-            ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
-
-      - name: Create env file for docker
-        run: |
-          cat <<-EOF > docker_env.txt
-          VCPKG_BINARY_SOURCES=$VCPKG_BINARY_SOURCES
-          USE_MERGED_VCPKG_MANIFEST=${{ inputs.use_merged_vcpkg_manifest }}
-          AWS_ACCESS_KEY_ID=${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY=${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
-          AWS_ENDPOINT_URL=${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
-          AWS_DEFAULT_REGION=${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
-          AWS_REQUEST_CHECKSUM_CALCULATION=when_required
-          VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_target_triplet }}
-          VCPKG_OVERLAY_TRIPLETS=/duckdb_build_dir/${{ inputs.vcpkg_overlay_triplets }}
-          VCPKG_OVERLAY_PORTS=/duckdb_build_dir/${{ inputs.vcpkg_overlay_ports }}
-          CUDAARCHS=${{ inputs.cuda_archs }}
-          VCPKG_CUDA_VERSION=${{ inputs.cuda_version }}
-          BUILD_SHELL=${{ inputs.build_duckdb_shell && '1' || '0' }}
-          OPENSSL_ROOT_DIR=/duckdb_build_dir/build/${{ inputs.build_type }}/vcpkg_installed/${{ matrix.vcpkg_target_triplet }}
-          OPENSSL_DIR=/duckdb_build_dir/build/${{ inputs.build_type }}/vcpkg_installed/${{ matrix.vcpkg_target_triplet }}
-          OPENSSL_USE_STATIC_LIBS=true
-          DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }}
-          ENABLE_EXTENSION_AUTOINSTALL=1
-          ENABLE_EXTENSION_AUTOLOADING=1
-          EXTENSION_NAME=${{ inputs.extension_name }}
-          EXTENSION_CANONICAL=${{ inputs.extension_canonical }}
-          LINUX_CI_IN_DOCKER=1
-          GITHUB_ACTIONS=true
-          CI=true
-          CCACHE_MAXSIZE=1G
-          CCACHE_NOCOMPRESS=1
-          SUBSET_EXTENSIONS_TESTS=${{ inputs.extensions_test_selection }}
-          EOF
-          echo '${{ inputs.test_config }}'| jq -r '.test_env_variables // {} | to_entries | map("\(.key)=\(.value)")|.[]' >> docker_env.txt
-
-      - name: Generate timestamp for Ccache entry
-        id: ccache_timestamp
-        run: echo "timestamp=$(date -u '+%Y-%m-%d-%H;%M;%S')" >> "$GITHUB_OUTPUT"
-
-      - name: Create Ccache directory
-        run: |
-          mkdir ccache_dir
-
-      - name: Load Ccache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Setup / Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          path: ./ccache_dir
-          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}-${{ steps.ccache_timestamp.outputs.timestamp }}
+          python-version: '3.11'
+
+      - name: Checkout / Prepare sources
+        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
+
+      - name: Setup / Ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+        continue-on-error: true
+        with:
+          max-size: 5GB
+          evict-old-files: job
+          key: extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
           restore-keys: |
             ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+            extension-distribution-${{ matrix.duckdb_arch }}-
             ccache-extension-distribution-${{ matrix.duckdb_arch }}-
+          save: ${{ inputs.save_cache }}
 
-      - name: Configure retry command
-        shell: bash
-        run: |
-          if [ -f duckdb/scripts/ci/retry.py ]; then
-            echo "RETRY_COMMAND=python3 duckdb/scripts/ci/retry.py --" >> "$GITHUB_ENV"
-          else
-            echo "RETRY_COMMAND=" >> "$GITHUB_ENV"
-          fi
+      - name: Setup
+        run: python3 extension-ci-tools/scripts/ci_phase.py setup
 
-      - name: Run configure (outside Docker)
-        shell: bash
-        env:
-          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
-          LINUX_CI_IN_DOCKER: 0
-        run: |
-          ${RETRY_COMMAND} make configure_ci
+      - name: Build
+        run: python3 extension-ci-tools/scripts/ci_phase.py build
 
-      - name: Install extra vcpkg dependencies
-        if: ${{ inputs.vcpkg_extra_dependencies != '' }}
-        run: |
-          JSON='${{inputs.vcpkg_extra_dependencies}}'
-          DEPS=$(python3 -c "import json; data=json.loads(r'$JSON'); print(' '.join(data.get('${{ matrix.duckdb_arch }}', [])) if '${{ matrix.duckdb_arch }}' in data else '')" | tr -d '\n')
-          if [ ! -z "$DEPS" ]; then
-            for dep in $DEPS; do
-              docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir duckdb/${{ matrix.duckdb_arch }} vcpkg install $dep --recurse
-            done
-          fi
+      - name: Test
+        run: python3 extension-ci-tools/scripts/ci_phase.py test
 
-      - name: Inject extra extension config
-        if: ${{ inputs.extra_extension_config }}
-        shell: bash
-        env:
-          EXTENSION_CONFIG: ${{ inputs.extra_extension_config }}
-        run: |
-          echo -e "\n# Injected Extension Config\n$EXTENSION_CONFIG" >> ./extension_config.cmake
-          cat ./extension_config.cmake
+      - name: Upload / Prepare artifacts
+        id: artifacts
+        run: python3 extension-ci-tools/scripts/ci_phase.py upload
 
-      - name: Run configure (inside Docker)
-        shell: bash
-        run: |
-          ${RETRY_COMMAND} docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make configure_ci
-
-      - name: Build extension (inside Docker)
-        run: |
-          ${RETRY_COMMAND} docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make ${{ inputs.build_type }}
-
-      - name: Run post build command
-        if: ${{ inputs.post_build_command != '' }}
-        shell: bash
-        env:
-          MATRIX_RUNNER: ${{ matrix.runner }}
-        run: ${{ inputs.post_build_command }}
-
-      - name: Save Ccache
-        if: ${{ inputs.save_cache }}
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ./ccache_dir
-          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}-${{ steps.ccache_timestamp.outputs.timestamp }}
-
-      - name: Test extension (inside docker)
-        if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
-        run: |
-          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test_${{ inputs.build_type }}
-
-      - name: Test extension (outside docker)
-        if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
-        env:
-          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
-          LINUX_CI_IN_DOCKER: 0
-          SUBSET_EXTENSIONS_TESTS: ${{ inputs.extensions_test_selection }}
-        run: |
-          eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
-          make test_${{ inputs.build_type }}
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ !inputs.upload_all_extensions }}
+      - name: Upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           if-no-files-found: error
-          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
-          path: |
-            build/${{ inputs.build_type }}/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ inputs.upload_all_extensions }}
-        with:
-          if-no-files-found: error
-          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
-          path: |
-            build/${{ inputs.build_type }}/repository/**/*.duckdb_extension
-
-      - name: Print Rust logs
-        if: ${{ inputs.rust_logs && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
-        run: |
-          if find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0 | grep -qz .; then
-            while IFS= read -r -d '' filename; do
-              echo "Printing logs for file $filename"
-              cat "$filename"
-              echo "Done printing logs for $filename"
-            done < <(find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0)
-          else
-            echo "No Rust build logs found under build/${{ inputs.build_type }}/rust/src/"
-          fi
+          name: ${{ steps.artifacts.outputs.artifact_name }}
+          path: ${{ steps.artifacts.outputs.artifact_path }}
 
   macos:
     name: ${{ matrix.duckdb_arch }}
@@ -558,243 +389,97 @@ jobs:
       (inputs.reduced_ci_mode == 'disabled' || needs.linux.result == 'success' || needs.linux.result == 'skipped')
     strategy:
       fail-fast: ${{ inputs.reduced_ci_mode != 'disabled' }}
-      matrix: ${{fromJson(needs.generate_matrix.outputs.osx_matrix)}}
+      matrix: ${{ fromJson(needs.generate_matrix.outputs.osx_matrix) }}
     env:
-      # VCPKG config
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
       VCPKG_OVERLAY_PORTS: ${{ github.workspace }}/extension-ci-tools/vcpkg_ports
       VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}/extension-ci-tools/toolchains
       USE_MERGED_VCPKG_MANIFEST: ${{ inputs.use_merged_vcpkg_manifest }}
-      # VCPKG caching
       AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
       AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
       AWS_REQUEST_CHECKSUM_CALCULATION: when_required
-      # Misc
       OSX_BUILD_ARCH: ${{ matrix.osx_build_arch }}
       GEN: ninja
       BUILD_SHELL: ${{ inputs.build_duckdb_shell && '1' || '0' }}
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      CI_PLATFORM: macos
+      CI_MATRIX_RUNNER: ${{ matrix.runner }}
+      CI_OSX_BUILD_ARCH: ${{ matrix.osx_build_arch }}
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout override repository
-        if: ${{inputs.override_repository != ''}}
+      - name: Checkout / Extension repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: ${{ inputs.override_repository }}
-          ref: ${{ inputs.override_ref }}
+          repository: ${{ inputs.override_repository != '' && inputs.override_repository || github.repository }}
+          ref: ${{ inputs.override_repository != '' && inputs.override_ref || '' }}
           fetch-depth: 0
-          submodules: 'recursive'
+          submodules: recursive
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout current repository
-        if: ${{inputs.override_repository == ''}}
+      - name: Checkout / Extension CI tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - name: Install Ninja
-        run: |
-          brew install ninja autoconf make libtool automake autoconf-archive
-
-      - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
-        continue-on-error: true
-        with:
-          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
-          restore-keys: ccache-extension-distribution-${{ matrix.duckdb_arch }}-
-          save: ${{ inputs.save_cache }}
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.11'
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout Extension CI tools
-        with:
-          path: 'extension-ci-tools'
+          path: extension-ci-tools
           ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
 
-      - name: Fetch override repository
-        if: ${{inputs.override_duckdb_repository != ''}}
-        run: |
-          DUCKDB_GIT_REPOSITORY=${{ inputs.override_duckdb_repository }} make set_duckdb_repository
+      - name: Checkout / Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.11'
 
-      - name: Set DuckDB to ref of calling workflow
-        if: ${{inputs.set_caller_as_duckdb}}
+      - name: Checkout / DuckDB from calling workflow
+        if: ${{ inputs.set_caller_as_duckdb }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          path: 'duckdb'
+          path: duckdb
           fetch-tags: true
           fetch-depth: 0
 
-      - name: Checkout DuckDB to version
-        if: ${{ inputs.duckdb_version != '' }}
-        run: |
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
+      - name: Checkout / Prepare sources
+        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
 
-      - name: Tag extension
-        if: ${{inputs.extension_tag != ''}}
-        run: |
-          git tag ${{ inputs.extension_tag }}
-
-      - name: Tag DuckDB extension
-        if: ${{inputs.duckdb_tag != ''}}
-        run: |
-          DUCKDB_TAG=${{ inputs.duckdb_tag }} make set_duckdb_tag
-
-      - name: Setup vcpkg
-        run: |
-          mkdir local_vcpkg_installation
-          cmake --version
-          cd local_vcpkg_installation
-          git init
-          git remote add origin ${{ inputs.vcpkg_url }}
-          git fetch origin ${{ inputs.vcpkg_commit }}
-          git checkout ${{ inputs.vcpkg_commit }}
-          ./bootstrap-vcpkg.sh
-          echo "VCPKG_ROOT=${{ github.workspace }}/local_vcpkg_installation" >> $GITHUB_ENV
-          echo "VCPKG_TOOLCHAIN_PATH=${{ github.workspace }}/local_vcpkg_installation/scripts/buildsystems/vcpkg.cmake" >> $GITHUB_ENV
-          echo "${{ github.workspace }}/local_vcpkg_installation" >> $GITHUB_PATH
-
-      - name: Install Rust cross compile dependency
-        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && matrix.osx_build_arch == 'x86_64'}}
-        run: |
-          rustup target add x86_64-apple-darwin
-
-      - name: Install Fortran
-        if: ${{ (contains(format(';{0};', inputs.extra_toolchains), ';fortran;')) }}
-        run: |
-          brew install gcc
-
-      - name: 'Setup go'
-        if: ${{ (inputs.enable_go || contains(format(';{0};', inputs.extra_toolchains), ';go;'))}}
+      - name: Setup / Go
+        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';go;') }}
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.23'
 
-      - name: Install parser tools
-        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';parser_tools;')}}
-        run: |
-          brew install bison flex
+      - name: Setup / Ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+        continue-on-error: true
+        with:
+          max-size: 5GB
+          evict-old-files: job
+          key: extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+          restore-keys: |
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+            extension-distribution-${{ matrix.duckdb_arch }}-
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-
+          save: ${{ inputs.save_cache }}
 
-      - name: Inject extra extension config
-        if: ${{ inputs.extra_extension_config }}
-        shell: bash
-        env:
-          EXTENSION_CONFIG: ${{ inputs.extra_extension_config }}
-        run: |
-          echo -e "\n# Injected Extension Config\n$EXTENSION_CONFIG" >> ./extension_config.cmake
-          cat ./extension_config.cmake
+      - name: Setup
+        run: python3 extension-ci-tools/scripts/ci_phase.py setup
 
-      - name: install omp (x86)
-        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';omp;') && matrix.duckdb_arch == 'osx_amd64' }}
-        run: |
-          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-          (echo; echo 'eval "$(/usr/local/bin/brew shellenv)"') >> /Users/runner/.bash_profile
-          eval "$(/usr/local/bin/brew shellenv)"
-          arch -x86_64 brew install libomp
-          echo "LDFLAGS=-L/usr/local/opt/libomp/lib" >> $GITHUB_ENV
-          echo "CFLAGS=-I/usr/local/opt/libomp/include" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I/usr/local/opt/libomp/include" >> $GITHUB_ENV
-          echo "CXXFLAGS=-I/usr/local/opt/libomp/include" >> $GITHUB_ENV
+      - name: Build
+        run: python3 extension-ci-tools/scripts/ci_phase.py build
 
-      - name: install omp (arm)
-        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';omp;') && matrix.duckdb_arch == 'osx_arm64' }}
-        run: |
-          brew install libomp
-          echo "LDFLAGS=-L/opt/homebrew/opt/libomp/lib" >> $GITHUB_ENV
-          echo "CFLAGS=-I/opt/homebrew/opt/libomp/include" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I/opt/homebrew/opt/libomp/include" >> $GITHUB_ENV
-          echo "CXXFLAGS=-I/opt/homebrew/opt/libomp/include" >> $GITHUB_ENV
+      - name: Test
+        run: python3 extension-ci-tools/scripts/ci_phase.py test
 
-      - name: Install unixODBC (arm64)
-        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';unixodbc;') && matrix.duckdb_arch == 'osx_arm64' }}
-        run: |
-          brew config
-          brew install unixodbc
-          brew ls -v unixodbc
+      - name: Upload / Prepare artifacts
+        id: artifacts
+        run: python3 extension-ci-tools/scripts/ci_phase.py upload
 
-      - name: Install unixODBC (amd64)
-        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';unixodbc;') && matrix.duckdb_arch == 'osx_amd64' }}
-        run: |
-          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          /usr/local/bin/brew config
-          /usr/local/bin/brew install unixodbc
-          /usr/local/bin/brew ls -v unixodbc
-
-      - name: Override AWS CLI
-        if: ${{ (contains(format(';{0};', inputs.extra_toolchains), ';downgraded_aws_cli;')) }}
-        shell: bash
-        run: |
-          curl https://awscli.amazonaws.com/AWSCLIV2-2.22.35.pkg -o ./AWSCLIV2.pkg
-          sudo installer -pkg ./AWSCLIV2.pkg -target /
-          aws --version
-
-      - name: Run configure
-        shell: bash
-        env:
-          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
-        run: |
-          make configure_ci
-
-      - name: Install extra vcpkg dependencies
-        if: ${{ inputs.vcpkg_extra_dependencies != '' }}
-        run: |
-          JSON='${{inputs.vcpkg_extra_dependencies}}'
-          DEPS=$(python3 -c "import json; data=json.loads(r'$JSON'); print(' '.join(data.get('${{ matrix.duckdb_arch }}', [])) if '${{ matrix.duckdb_arch }}' in data else '')" | tr -d '\n')
-          if [ ! -z "$DEPS" ]; then
-            for dep in $DEPS; do
-              vcpkg install "$dep" --recurse
-            done
-          fi
-
-      - name: Build extension
-        shell: bash
-        run: |
-          EXTENSION_NAME=${{ inputs.extension_name }} EXTENSION_CANONICAL=${{ inputs.extension_canonical }} ENABLE_EXTENSION_AUTOINSTALL=1 ENABLE_EXTENSION_AUTOLOADING=1 make ${{ inputs.build_type }}
-
-      - name: Test Extension
-        if: ${{ matrix.osx_build_arch == 'arm64' && inputs.skip_tests == false }}
-        env:
-          SUBSET_EXTENSIONS_TESTS: ${{ inputs.extensions_test_selection }}
-        shell: bash
-        run: |
-          eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
-          make test_${{ inputs.build_type }}
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ !inputs.upload_all_extensions }}
+      - name: Upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           if-no-files-found: error
-          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
-          path: |
-            build/${{ inputs.build_type }}/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ inputs.upload_all_extensions }}
-        with:
-          if-no-files-found: error
-          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
-          path: |
-            build/${{ inputs.build_type }}/repository/**/*.duckdb_extension
-
-      - name: Print Rust logs
-        if: ${{ inputs.rust_logs && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
-        run: |
-          if find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0 | grep -qz .; then
-            while IFS= read -r -d '' filename; do
-              echo "Printing logs for file $filename"
-              cat "$filename"
-              echo "Done printing logs for $filename"
-            done < <(find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0)
-          else
-            echo "No Rust build logs found under build/${{ inputs.build_type }}/rust/src/"
-          fi
+          name: ${{ steps.artifacts.outputs.artifact_name }}
+          path: ${{ steps.artifacts.outputs.artifact_path }}
 
   windows:
     name: ${{ matrix.duckdb_arch }}
@@ -811,284 +496,135 @@ jobs:
       (inputs.reduced_ci_mode == 'disabled' || needs.linux.result == 'success' || needs.linux.result == 'skipped')
     strategy:
       fail-fast: ${{ inputs.reduced_ci_mode != 'disabled' }}
-      matrix: ${{fromJson(needs.generate_matrix.outputs.windows_matrix)}}
+      matrix: ${{ fromJson(needs.generate_matrix.outputs.windows_matrix) }}
     env:
-      # VCPKG config
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
       VCPKG_OVERLAY_PORTS: ${{ github.workspace }}/extension-ci-tools/vcpkg_ports
       VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}/extension-ci-tools/toolchains
       USE_MERGED_VCPKG_MANIFEST: ${{ inputs.use_merged_vcpkg_manifest }}
-      # VCPKG caching
       AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
       AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
       AWS_REQUEST_CHECKSUM_CALCULATION: when_required
-      # Misc
       BUILD_SHELL: ${{ inputs.build_duckdb_shell && '1' || '0' }}
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
       CC: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 'gcc' || 'cl' }}
       CXX: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 'g++' || 'cl' }}
       GEN: ninja
+      CI_PLATFORM: windows
+      CI_MATRIX_RUNNER: ${{ matrix.runner }}
 
     steps:
-      - name: Downgrade AWS cli
-        shell: powershell
-        if: ${{ (contains(format(';{0};', inputs.extra_toolchains), ';downgraded_aws_cli;')) }}
-        run: |
-          $app = Get-WmiObject -Class Win32_Product -Filter "Name LIKE 'AWS Command Line Interface%'"
-          if ($app) { $app.Uninstall() }
-          msiexec.exe /i https://awscli.amazonaws.com/AWSCLIV2-2.22.35.msi  /qn
-          sleep 60
-
-      - name: Test AWS cli version
-        shell: powershell
-        run: |
-          aws --version
-
-      - name: Keep \n line endings
+      - name: Checkout / Configure line endings
         shell: bash
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout override repository
-        if: ${{inputs.override_repository != ''}}
+      - name: Checkout / Extension repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: ${{ inputs.override_repository }}
-          ref: ${{ inputs.override_ref }}
+          repository: ${{ inputs.override_repository != '' && inputs.override_repository || github.repository }}
+          ref: ${{ inputs.override_repository != '' && inputs.override_ref || '' }}
           fetch-depth: 0
-          submodules: 'recursive'
+          submodules: recursive
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout current repository
-        if: ${{inputs.override_repository == ''}}
+      - name: Checkout / Extension CI tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
-          submodules: 'recursive'
+          path: extension-ci-tools
+          ref: ${{ inputs.ci_tools_version }}
+          repository: ${{ inputs.override_ci_tools_repository }}
 
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      - name: Checkout / Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.11'
 
-      - name: Setup Rust
-        if: (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;'))
+      - name: Checkout / DuckDB from calling workflow
+        if: ${{ inputs.set_caller_as_duckdb }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: duckdb
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Checkout / Prepare sources
+        run: python extension-ci-tools/scripts/ci_phase.py checkout
+
+      - name: Setup / Rust
+        if: ${{ inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;') }}
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
-      - name: Setup Rust for Mingw
-        if: (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw'
+      - name: Setup / Rust for MinGW
+        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) && (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') }}
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: x86_64-pc-windows-gnu
 
-      - name: 'Setup go'
-        if: ${{ (inputs.enable_go || contains(format(';{0};', inputs.extra_toolchains), ';go;'))}}
+      - name: Setup / Go
+        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';go;') }}
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.23'
 
-      - name: Install parser tools
-        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';parser_tools;')}}
-        run: |
-          choco install winflexbison3
-
-      - name: Install Ninja build tool
-        run: |
-          choco install ninja -y
-
-      - name: Install jq
-        run: |
-          choco install jq -y
-
-      - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
-        continue-on-error: true
+      - name: Setup / Rtools
+        if: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw' }}
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
-          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
-          restore-keys: ccache-extension-distribution-${{ matrix.duckdb_arch }}-
-          save: ${{ inputs.save_cache }}
-
-      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
-        if:  matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw'
-        with:
-          r-version: 'devel'
+          r-version: devel
           update-rtools: true
-          rtools-version: '42' # linker bug in 43
+          rtools-version: '42'
 
-      - name: setup rtools gcc for vcpkg
-        if:  matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw'
+      - name: Setup / Short vcpkg path
+        shell: pwsh
         run: |
-          cp C:/rtools42/x86_64-w64-mingw32.static.posix/bin/gcc.exe C:/rtools42/x86_64-w64-mingw32.static.posix/bin/x86_64-w64-mingw32-gcc.exe
-          cp C:/rtools42/x86_64-w64-mingw32.static.posix/bin/g++.exe C:/rtools42/x86_64-w64-mingw32.static.posix/bin/x86_64-w64-mingw32-g++.exe
-          cp C:/rtools42/x86_64-w64-mingw32.static.posix/bin/gfortran.exe C:/rtools42/x86_64-w64-mingw32.static.posix/bin/x86_64-w64-mingw32-gfortran.exe
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout Extension CI tools
-        with:
-          path: 'extension-ci-tools'
-          ref: ${{ inputs.ci_tools_version }}
-          repository: ${{ inputs.override_ci_tools_repository }}
-
-      - name: Fetch override repository
-        if: ${{inputs.override_duckdb_repository != ''}}
-        env:
-          DUCKDB_GIT_REPOSITORY: ${{ inputs.override_duckdb_repository }}
-        run: |
-          make set_duckdb_repository
-
-      - name: Set DuckDB to ref of calling workflow
-        if: ${{inputs.set_caller_as_duckdb}}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          path: 'duckdb'
-          fetch-tags: true
-          fetch-depth: 0
-
-      - name: Checkout DuckDB to version
-        if: ${{ inputs.duckdb_version != '' }}
-        env:
-          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
-        run: |
-          make set_duckdb_version
-
-      - name: Tag extension
-        if: ${{inputs.extension_tag != ''}}
-        run: |
-          git tag ${{ inputs.extension_tag }}
-
-      - name: Tag DuckDB extension
-        if: ${{inputs.duckdb_tag != ''}}
-        env:
-          DUCKDB_TAG: ${{ inputs.duckdb_tag }}
-        run: |
-          make set_duckdb_tag
-
-      - name: Setup shorter path for vcpkg
-        run: |
-          $basePath = Split-Path -Path (Split-path -Path $env:GITHUB_WORKSPACE -Parent) -Parent
+          $basePath = Split-Path -Path (Split-Path -Path $env:GITHUB_WORKSPACE -Parent) -Parent
           $vcpkgRoot = "$basePath/vcpkg"
           echo "VCPKG_WINDOWS_ROOT=$vcpkgRoot" >> $env:GITHUB_ENV
           echo "VCPKG_TOOLCHAIN_PATH=$vcpkgRoot/scripts/buildsystems/vcpkg.cmake" >> $env:GITHUB_ENV
-        shell: pwsh
 
-      - name: Setup vcpkg
+      - name: Setup / Vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
         with:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
           vcpkgGitURL: ${{ inputs.vcpkg_url }}
           vcpkgDirectory: ${{ env.VCPKG_WINDOWS_ROOT }}
 
-      - name: Inject extra extension config
-        if: ${{ inputs.extra_extension_config }}
-        shell: bash
-        env:
-          EXTENSION_CONFIG: ${{ inputs.extra_extension_config }}
-        run: |
-          echo -e "\n# Injected Extension Config\n$EXTENSION_CONFIG" >> ./extension_config.cmake
-          cat ./extension_config.cmake
+      - name: Setup / Ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+        continue-on-error: true
+        with:
+          max-size: 5GB
+          evict-old-files: job
+          key: extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+          restore-keys: |
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+            extension-distribution-${{ matrix.duckdb_arch }}-
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-
+          save: ${{ inputs.save_cache }}
 
-      - name: Run configure
-        shell: bash
-        env:
-          DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-          DUCKDB_PLATFORM_RTOOLS: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 1 || 0 }}
-          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
-        run: |
-          make configure_ci
+      - name: Setup
+        run: python extension-ci-tools/scripts/ci_phase.py setup
 
-      - name: Install extra vcpkg dependencies
-        shell: bash
-        if: ${{ inputs.vcpkg_extra_dependencies != '' }}
-        run: |
-          JSON='${{inputs.vcpkg_extra_dependencies}}'
-          DEPS=$(python3 -c "import json; data=json.loads(r'$JSON'); print(' '.join(data.get('${{ matrix.duckdb_arch }}', [])) if '${{ matrix.duckdb_arch }}' in data else '')" | tr -d '\n')
-          echo $DEPS
-          if [ ! -z "$DEPS" ]; then
-            for dep in $DEPS; do
-              vcpkg install "$dep" --recurse
-            done
-          fi
+      - name: Build
+        run: python extension-ci-tools/scripts/ci_phase.py build
 
-      - name: Build extension
-        env:
-          DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-          EXTENSION_NAME: ${{ inputs.extension_name }}
-          EXTENSION_CANONICAL: ${{ inputs.extension_canonical }}
-          ENABLE_EXTENSION_AUTOINSTALL: 1
-          ENABLE_EXTENSION_AUTOLOADING: 1
-          DUCKDB_PLATFORM_RTOOLS: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 1 || 0 }}
-          EXT_FLAGS: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        shell: cmd
-        run: |
-          setlocal EnableDelayedExpansion
-          if "%DUCKDB_PLATFORM_RTOOLS%" == "0" (
-            set "VCVARS_BAT="
-            if "%DUCKDB_PLATFORM%" == "windows_amd64" (
-              set "VCVARS_BAT=vcvars64.bat"
-            )
-            if "%DUCKDB_PLATFORM%" == "windows_arm64" (
-              set "VCVARS_BAT=vcvarsarm64.bat"
-            )
-            if defined VCVARS_BAT (
-              if exist "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\!VCVARS_BAT!" (
-                call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\!VCVARS_BAT!"
-              ) else (
-                call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\!VCVARS_BAT!"
-              )
-            )
-            REM Rename link.exe to link-git.exe to avoid conflicts with git supplied linker.
-            mv "C:\Program Files\Git\usr\bin\link.exe" "C:\Program Files\Git\usr\bin\link-git.exe"
-          )
-          make ${{ inputs.build_type }}
+      - name: Test
+        run: python extension-ci-tools/scripts/ci_phase.py test
 
-      - name: Test extension
-        if: ${{ inputs.skip_tests == false }}
-        shell: bash
-        env:
-          DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-          DUCKDB_PLATFORM_RTOOLS: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 1 || 0 }}
-          SUBSET_EXTENSIONS_TESTS: ${{ inputs.extensions_test_selection }}
-        run: |
-          eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
-          make test_${{ inputs.build_type }}
+      - name: Upload / Prepare artifacts
+        id: artifacts
+        run: python extension-ci-tools/scripts/ci_phase.py upload
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ !inputs.upload_all_extensions }}
+      - name: Upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           if-no-files-found: error
-          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
-          path: |
-            build/${{ inputs.build_type }}/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ inputs.upload_all_extensions }}
-        with:
-          if-no-files-found: error
-          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
-          path: |
-            build/${{ inputs.build_type }}/repository/**/*.duckdb_extension
-
-      - name: Print Rust logs
-        if: ${{ inputs.rust_logs && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
-        shell: bash
-        run: |
-          if find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0 | grep -qz .; then
-            while IFS= read -r -d '' filename; do
-              echo "Printing logs for file $filename"
-              cat "$filename"
-              echo "Done printing logs for $filename"
-            done < <(find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0)
-          else
-            echo "No Rust build logs found under build/${{ inputs.build_type }}/rust/src/"
-          fi
-
-      - name: Move rtools supplied zstd out of the way, so ccache can work
-        if: (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw')
-        shell: cmd
-        run: |
-          mv C:\rtools42\usr\bin\zstd.exe C:\rtools42\usr\bin\zstd-rtools.exe
+          name: ${{ steps.artifacts.outputs.artifact_name }}
+          path: ${{ steps.artifacts.outputs.artifact_path }}
 
   wasm:
     name: ${{ matrix.duckdb_arch }}
@@ -1105,7 +641,7 @@ jobs:
       (inputs.reduced_ci_mode == 'disabled' || needs.linux.result == 'success' || needs.linux.result == 'skipped')
     strategy:
       fail-fast: ${{ inputs.reduced_ci_mode != 'disabled' }}
-      matrix: ${{fromJson(needs.generate_matrix.outputs.wasm_matrix)}}
+      matrix: ${{ fromJson(needs.generate_matrix.outputs.wasm_matrix) }}
     env:
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
@@ -1113,186 +649,94 @@ jobs:
       USE_MERGED_VCPKG_MANIFEST: ${{ inputs.use_merged_vcpkg_manifest }}
       VCPKG_OVERLAY_PORTS: ${{ github.workspace }}/extension-ci-tools/vcpkg_ports
       VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}/extension-ci-tools/toolchains
-      # VCPKG caching
       AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
       AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
       AWS_REQUEST_CHECKSUM_CALCULATION: when_required
-
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
       WASM_EXTENSIONS: 1
+      CI_PLATFORM: wasm
+      CI_MATRIX_RUNNER: ${{ matrix.runner }}
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout override repository
-        if: ${{inputs.override_repository != ''}}
+      - name: Checkout / Extension repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: ${{ inputs.override_repository }}
-          ref: ${{ inputs.override_ref }}
+          repository: ${{ inputs.override_repository != '' && inputs.override_repository || github.repository }}
+          ref: ${{ inputs.override_repository != '' && inputs.override_ref || '' }}
           fetch-depth: 0
-          submodules: 'recursive'
+          submodules: recursive
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout current repository
-        if: ${{inputs.override_repository == ''}}
+      - name: Checkout / Extension CI tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout Extension CI tools
-        with:
-          path: 'extension-ci-tools'
+          path: extension-ci-tools
           ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
 
-      - name: Fetch override repository
-        if: ${{inputs.override_duckdb_repository != ''}}
-        run: |
-          DUCKDB_GIT_REPOSITORY=${{ inputs.override_duckdb_repository }} make set_duckdb_repository
+      - name: Checkout / Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.11'
 
-      - name: Set DuckDB to ref of calling workflow
-        if: ${{inputs.set_caller_as_duckdb}}
+      - name: Checkout / DuckDB from calling workflow
+        if: ${{ inputs.set_caller_as_duckdb }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          path: 'duckdb'
+          path: duckdb
           fetch-tags: true
           fetch-depth: 0
 
-      - name: Checkout DuckDB to version
-        if: ${{ inputs.duckdb_version != '' }}
-        run: |
-          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
+      - name: Checkout / Prepare sources
+        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
 
-      - name: Tag extension
-        if: ${{inputs.extension_tag != ''}}
-        run: |
-          git tag ${{ inputs.extension_tag }}
-
-      - name: Tag DuckDB extension
-        if: ${{inputs.duckdb_tag != ''}}
-        run: |
-          DUCKDB_TAG=${{ inputs.duckdb_tag }} make set_duckdb_tag
-
-      - uses: emscripten-core/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
+      - name: Setup / Emscripten
+        uses: emscripten-core/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
         with:
           version: 3.1.71
 
-      - name: Setup Rust for cross compilation
-        if: ${{ (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;'))}}
+      - name: Setup / Rust
+        if: ${{ inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;') }}
         uses: dtolnay/rust-toolchain@4d407b29186a635f0cc27475ef0bc0ae605a8866 # 1.86.0
         with:
           targets: wasm32-unknown-emscripten
 
-      - name: 'Setup go'
-        if: ${{ (inputs.enable_go || contains(format(';{0};', inputs.extra_toolchains), ';go;'))}}
+      - name: Setup / Go
+        if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';go;') }}
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.23'
 
-      - name: Setup vcpkg
-        run: |
-          mkdir local_vcpkg_installation
-          cmake --version
-          cd local_vcpkg_installation
-          git init
-          git remote add origin ${{ inputs.vcpkg_url }}
-          git fetch origin ${{ inputs.vcpkg_commit }}
-          git checkout ${{ inputs.vcpkg_commit }}
-          ./bootstrap-vcpkg.sh
-          echo "VCPKG_ROOT=${{ github.workspace }}/local_vcpkg_installation" >> $GITHUB_ENV
-          echo "VCPKG_TOOLCHAIN_PATH=${{ github.workspace }}/local_vcpkg_installation/scripts/buildsystems/vcpkg.cmake" >> $GITHUB_ENV
-          echo "${{ github.workspace }}/local_vcpkg_installation" >> $GITHUB_PATH
-
-      - name: Setup Ccache
+      - name: Setup / Ccache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         continue-on-error: true
         with:
-          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
-          restore-keys: ccache-extension-distribution-${{ matrix.duckdb_arch }}-
+          max-size: 5GB
+          evict-old-files: job
+          key: extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+          restore-keys: |
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+            extension-distribution-${{ matrix.duckdb_arch }}-
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-
           save: ${{ inputs.save_cache }}
 
-      - name: Downgrade AWS cli
-        if: ${{ (contains(format(';{0};', inputs.extra_toolchains), ';downgraded_aws_cli;')) }}
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.35.zip" -o "awscliv2.zip"
-          unzip -q awscliv2.zip
-          sudo ./aws/install --update
-          aws --version
+      - name: Setup
+        run: python3 extension-ci-tools/scripts/ci_phase.py setup
 
-      - name: Inject extra extension config
-        if: ${{ inputs.extra_extension_config }}
-        shell: bash
-        env:
-          EXTENSION_CONFIG: ${{ inputs.extra_extension_config }}
-        run: |
-          echo -e "\n# Injected Extension Config\n$EXTENSION_CONFIG" >> ./extension_config.cmake
-          cat ./extension_config.cmake
+      - name: Build
+        run: python3 extension-ci-tools/scripts/ci_phase.py build
 
-      - name: Configure retry command
-        shell: bash
-        run: |
-          if [ -f duckdb/scripts/ci/retry.py ]; then
-            echo "RETRY_COMMAND=python3 duckdb/scripts/ci/retry.py --" >> "$GITHUB_ENV"
-          else
-            echo "RETRY_COMMAND=" >> "$GITHUB_ENV"
-          fi
+      - name: Test
+        run: python3 extension-ci-tools/scripts/ci_phase.py test
 
-      - name: Run configure
-        shell: bash
-        env:
-          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
-        run: |
-          ${RETRY_COMMAND} make configure_ci
+      - name: Upload / Prepare artifacts
+        id: artifacts
+        run: python3 extension-ci-tools/scripts/ci_phase.py upload
 
-      - name: Install extra vcpkg dependencies
-        if: ${{ inputs.vcpkg_extra_dependencies != '' }}
-        shell: bash
-        run: |
-          JSON='${{inputs.vcpkg_extra_dependencies}}'
-          DEPS=$(python3 -c "import json; data=json.loads(r'$JSON'); print(' '.join(data.get('${{ matrix.duckdb_arch }}', [])) if '${{ matrix.duckdb_arch }}' in data else '')" | tr -d '\n')
-          if [ ! -z "$DEPS" ]; then
-            for dep in $DEPS; do
-              vcpkg install "$dep" --recurse
-            done
-          fi
-
-      - name: Build Wasm module
-        env:
-          EXTENSION_NAME: ${{ inputs.extension_name }}
-          EXTENSION_CANONICAL: ${{ inputs.extension_canonical }}
-          ENABLE_EXTENSION_AUTOINSTALL: 1
-          ENABLE_EXTENSION_AUTOLOADING: 1
-        run: |
-          ${RETRY_COMMAND} make ${{ matrix.duckdb_arch }}
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ !inputs.upload_all_extensions }}
+      - name: Upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           if-no-files-found: error
-          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
-          path: |
-            build/${{ matrix.duckdb_arch }}/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension.wasm
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ inputs.upload_all_extensions}}
-        with:
-          if-no-files-found: error
-          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
-          path: |
-            build/${{ matrix.duckdb_arch }}/repository/**/*.duckdb_extension.wasm
-
-      - name: Print Rust logs
-        if: ${{ inputs.rust_logs && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
-        shell: bash
-        run: |
-          if find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0 | grep -qz .; then
-            while IFS= read -r -d '' filename; do
-              echo "Printing logs for file $filename"
-              cat "$filename"
-              echo "Done printing logs for $filename"
-            done < <(find "build/${{ inputs.build_type }}/rust/src/" -type f -name '*build-*.log' -print0)
-          else
-            echo "No Rust build logs found under build/${{ inputs.build_type }}/rust/src/"
-          fi
+          name: ${{ steps.artifacts.outputs.artifact_name }}
+          path: ${{ steps.artifacts.outputs.artifact_path }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -567,6 +567,18 @@ jobs:
         with:
           go-version: '1.23'
 
+      - name: Setup / Ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+        with:
+          max-size: 5GB
+          evict-old-files: job
+          key: extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+          restore-keys: |
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+            extension-distribution-${{ matrix.duckdb_arch }}-
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-
+          save: ${{ inputs.save_cache }}
+
       - name: Setup / Rtools
         if: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw' }}
         uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
@@ -589,19 +601,6 @@ jobs:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
           vcpkgGitURL: ${{ inputs.vcpkg_url }}
           vcpkgDirectory: ${{ env.VCPKG_WINDOWS_ROOT }}
-
-      - name: Setup / Ccache
-        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
-        continue-on-error: true
-        with:
-          max-size: 5GB
-          evict-old-files: job
-          key: extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
-          restore-keys: |
-            ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
-            extension-distribution-${{ matrix.duckdb_arch }}-
-            ccache-extension-distribution-${{ matrix.duckdb_arch }}-
-          save: ${{ inputs.save_cache }}
 
       - name: Setup
         run: python extension-ci-tools/scripts/ci_phase.py setup

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -333,11 +333,8 @@ jobs:
           remove_folders: "/usr/local/share/powershell /usr/share/swift"
           testing: false
 
-      - name: Setup / Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.11'
-
+      # Use system Python: Linux host configuration creates configure/venv, which must
+      # remain usable inside the bind-mounted Docker workspace.
       - name: Checkout / Prepare sources
         run: python3 extension-ci-tools/scripts/ci_phase.py checkout
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -435,7 +435,8 @@ class PhaseRunner:
                 )
             commands.append('if exist "C:\\Program Files\\Git\\usr\\bin\\link.exe" move "C:\\Program Files\\Git\\usr\\bin\\link.exe" "C:\\Program Files\\Git\\usr\\bin\\link-git.exe"')
         commands.append(f"make {self.required('CI_BUILD_TYPE')}")
-        self.run(["cmd.exe", "/d", "/s", "/c", " && ".join(commands)], extra_env=environment)
+        # cmd.exe does not understand the C-runtime quote escaping used for argument lists.
+        self.run(" && ".join(commands), shell=True, extra_env=environment)
 
     def build_wasm(self) -> None:
         self.run_with_retry(["make", self.architecture], extra_env=self.build_environment())

--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""Run command-based phases of the extension distribution workflow.
+
+GitHub actions that need ``uses:`` remain in the workflow.  Everything else is
+kept here so optional operations do not each become a top-level Actions step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Mapping, Sequence
+
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def is_true(value: str | None) -> bool:
+    return (value or "").lower() in TRUE_VALUES
+
+
+def tool_enabled(toolchains: str, tool: str) -> bool:
+    return f";{tool};" in f";{toolchains.strip(';')};"
+
+
+def test_environment(config: str) -> dict[str, str]:
+    parsed = json.loads(config or "{}")
+    values = parsed.get("test_env_variables", {})
+    if not isinstance(values, dict):
+        raise ValueError("test_env_variables must be a JSON object")
+    def stringify(value: object) -> str:
+        if isinstance(value, bool):
+            return str(value).lower()
+        if value is None:
+            return "null"
+        return str(value)
+
+    return {str(key): stringify(value) for key, value in values.items()}
+
+
+def extra_dependencies(config: str, architecture: str) -> list[str]:
+    if not config:
+        return []
+    parsed = json.loads(config)
+    values = parsed.get(architecture, [])
+    if not isinstance(values, list):
+        raise ValueError(f"vcpkg dependencies for {architecture} must be a list")
+    return [str(value) for value in values]
+
+
+class PhaseRunner:
+    def __init__(self, environ: Mapping[str, str] | None = None) -> None:
+        self.env = dict(os.environ if environ is None else environ)
+        self.platform = self.required("CI_PLATFORM")
+        self.architecture = self.required("DUCKDB_PLATFORM")
+        self.workspace = Path(self.env.get("GITHUB_WORKSPACE", ".")).resolve()
+
+    def value(self, name: str, default: str = "") -> str:
+        return self.env.get(name, default)
+
+    def required(self, name: str) -> str:
+        value = self.value(name)
+        if not value:
+            raise ValueError(f"missing required environment variable: {name}")
+        return value
+
+    def enabled(self, name: str) -> bool:
+        return is_true(self.value(name))
+
+    def run(
+        self,
+        command: Sequence[str] | str,
+        *,
+        extra_env: Mapping[str, str] | None = None,
+        shell: bool = False,
+        cwd: Path | None = None,
+    ) -> None:
+        environment = self.env.copy()
+        if extra_env:
+            environment.update(extra_env)
+        printable = command if isinstance(command, str) else " ".join(command)
+        print(f"+ {printable}", flush=True)
+        options = {
+            "check": True,
+            "cwd": cwd or self.workspace,
+            "env": environment,
+            "shell": shell,
+        }
+        if shell and os.name != "nt":
+            options["executable"] = shutil.which("bash") or "/bin/bash"
+        subprocess.run(command, **options)
+
+    def append_github_file(self, variable: str, name: str, value: str) -> None:
+        destination = self.value(variable)
+        if not destination:
+            return
+        with open(destination, "a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+
+    def set_environment(self, name: str, value: str) -> None:
+        self.env[name] = value
+        self.append_github_file("GITHUB_ENV", name, value)
+
+    def add_path(self, value: Path) -> None:
+        self.env["PATH"] = f"{value}{os.pathsep}{self.env.get('PATH', '')}"
+        destination = self.value("GITHUB_PATH")
+        if destination:
+            with open(destination, "a", encoding="utf-8") as handle:
+                handle.write(f"{value}\n")
+
+    def retry_prefix(self) -> list[str]:
+        retry_script = self.workspace / "duckdb" / "scripts" / "ci" / "retry.py"
+        return [sys.executable, str(retry_script), "--"] if retry_script.is_file() else []
+
+    def run_with_retry(
+        self, command: Sequence[str], *, extra_env: Mapping[str, str] | None = None
+    ) -> None:
+        self.run([*self.retry_prefix(), *command], extra_env=extra_env)
+
+    def checkout(self) -> None:
+        duckdb_repository = self.value("CI_DUCKDB_GIT_REPOSITORY")
+        if duckdb_repository:
+            self.run(
+                ["make", "set_duckdb_repository"],
+                extra_env={"DUCKDB_GIT_REPOSITORY": duckdb_repository},
+            )
+
+        duckdb_version = self.value("CI_DUCKDB_VERSION")
+        if duckdb_version:
+            self.run(
+                ["make", "set_duckdb_version"],
+                extra_env={"DUCKDB_GIT_VERSION": duckdb_version},
+            )
+
+        extension_tag = self.value("CI_EXTENSION_TAG")
+        if extension_tag:
+            self.run(["git", "tag", extension_tag])
+
+        duckdb_tag = self.value("CI_DUCKDB_TAG")
+        if duckdb_tag:
+            self.run(["make", "set_duckdb_tag"], extra_env={"DUCKDB_TAG": duckdb_tag})
+
+    def inject_extension_config(self) -> None:
+        config = self.value("CI_EXTRA_EXTENSION_CONFIG")
+        if not config:
+            return
+        path = self.workspace / "extension_config.cmake"
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(f"\n# Injected Extension Config\n{config}\n")
+        print(path.read_text(encoding="utf-8"))
+
+    def install_vcpkg(self) -> None:
+        installation = self.workspace / "local_vcpkg_installation"
+        installation.mkdir()
+        self.run(["cmake", "--version"])
+        self.run(["git", "init"], cwd=installation)
+        self.run(
+            ["git", "remote", "add", "origin", self.required("CI_VCPKG_URL")],
+            cwd=installation,
+        )
+        commit = self.required("CI_VCPKG_COMMIT")
+        self.run(["git", "fetch", "origin", commit], cwd=installation)
+        self.run(["git", "checkout", commit], cwd=installation)
+        self.run([str(installation / "bootstrap-vcpkg.sh")], cwd=installation)
+        self.set_environment("VCPKG_ROOT", str(installation))
+        self.set_environment(
+            "VCPKG_TOOLCHAIN_PATH", str(installation / "scripts/buildsystems/vcpkg.cmake")
+        )
+        self.add_path(installation)
+
+    def install_extra_vcpkg_dependencies(self, *, docker: bool = False) -> None:
+        dependencies = extra_dependencies(
+            self.value("CI_VCPKG_EXTRA_DEPENDENCIES"), self.architecture
+        )
+        for dependency in dependencies:
+            if docker:
+                self.run(
+                    [
+                        "docker",
+                        "run",
+                        "--env-file=docker_env.txt",
+                        "-v",
+                        f"{self.workspace}:/duckdb_build_dir",
+                        f"duckdb/{self.architecture}",
+                        "vcpkg",
+                        "install",
+                        dependency,
+                        "--recurse",
+                    ]
+                )
+            else:
+                self.run(["vcpkg", "install", dependency, "--recurse"])
+
+    def setup_linux(self) -> None:
+        if self.enabled("CI_USE_DEFAULT_RUNNERS"):
+            if self.enabled("CI_RUN_DISK_CLEAN_STEP"):
+                images = subprocess.run(
+                    ["docker", "images", "-a", "-q"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout.split()
+                if images:
+                    try:
+                        self.run(["docker", "rmi", *images])
+                    except subprocess.CalledProcessError as error:
+                        print(f"Warning: could not remove preinstalled Docker images: {error}")
+            self.run(["sudo", "systemctl", "stop", "docker"])
+            self.run(["sudo", "mkdir", "-p", "/mnt/docker-data"])
+            self.run(
+                "echo '{ \"data-root\": \"/mnt/docker-data\" }' | sudo tee /etc/docker/daemon.json",
+                shell=True,
+            )
+            self.run(["sudo", "systemctl", "start", "docker"])
+            self.run("docker info | grep 'Docker Root Dir'", shell=True)
+
+        self.run_with_retry(
+            ["make", "configure_ci"],
+            extra_env={
+                "DUCKDB_GIT_VERSION": self.value("CI_DUCKDB_VERSION"),
+                "LINUX_CI_IN_DOCKER": "0",
+            },
+        )
+
+    def setup_macos(self) -> None:
+        self.run(["brew", "install", "ninja", "autoconf", "make", "libtool", "automake", "autoconf-archive"])
+        self.install_vcpkg()
+        tools = self.value("CI_EXTRA_TOOLCHAINS")
+        osx_arch = self.value("CI_OSX_BUILD_ARCH")
+        if tool_enabled(tools, "rust") and osx_arch == "x86_64":
+            self.run(["rustup", "target", "add", "x86_64-apple-darwin"])
+        if tool_enabled(tools, "fortran"):
+            self.run(["brew", "install", "gcc"])
+        if tool_enabled(tools, "parser_tools"):
+            self.run(["brew", "install", "bison", "flex"])
+        if tool_enabled(tools, "omp"):
+            self.setup_macos_omp()
+        if tool_enabled(tools, "unixodbc"):
+            self.setup_macos_unixodbc()
+        if tool_enabled(tools, "downgraded_aws_cli"):
+            self.run(["curl", "https://awscli.amazonaws.com/AWSCLIV2-2.22.35.pkg", "-o", "AWSCLIV2.pkg"])
+            self.run(["sudo", "installer", "-pkg", "AWSCLIV2.pkg", "-target", "/"])
+            self.run(["aws", "--version"])
+        self.run(["make", "configure_ci"], extra_env={"DUCKDB_GIT_VERSION": self.value("CI_DUCKDB_VERSION")})
+        self.install_extra_vcpkg_dependencies()
+
+    def setup_macos_omp(self) -> None:
+        if self.architecture == "osx_amd64":
+            self.run(
+                'arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"',
+                shell=True,
+            )
+            self.run(["arch", "-x86_64", "/usr/local/bin/brew", "install", "libomp"])
+            prefix = "/usr/local/opt/libomp"
+        else:
+            self.run(["brew", "install", "libomp"])
+            prefix = "/opt/homebrew/opt/libomp"
+        self.set_environment("LDFLAGS", f"-L{prefix}/lib")
+        self.set_environment("CFLAGS", f"-I{prefix}/include")
+        self.set_environment("CPPFLAGS", f"-I{prefix}/include")
+        self.set_environment("CXXFLAGS", f"-I{prefix}/include")
+
+    def setup_macos_unixodbc(self) -> None:
+        if self.architecture == "osx_amd64":
+            self.run(
+                'arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"',
+                shell=True,
+            )
+            brew = "/usr/local/bin/brew"
+        else:
+            brew = "brew"
+        self.run([brew, "config"])
+        self.run([brew, "install", "unixodbc"])
+        self.run([brew, "ls", "-v", "unixodbc"])
+
+    def setup_windows(self) -> None:
+        tools = self.value("CI_EXTRA_TOOLCHAINS")
+        if tool_enabled(tools, "downgraded_aws_cli"):
+            command = (
+                "$app = Get-WmiObject -Class Win32_Product -Filter \"Name LIKE 'AWS Command Line Interface%'\"; "
+                "if ($app) { $app.Uninstall() }; "
+                "Start-Process msiexec.exe -ArgumentList '/i https://awscli.amazonaws.com/AWSCLIV2-2.22.35.msi /qn' -Wait"
+            )
+            self.run(["powershell", "-NoProfile", "-Command", command])
+        self.run(["aws", "--version"])
+        if tool_enabled(tools, "parser_tools"):
+            self.run(["choco", "install", "winflexbison3", "-y"])
+        self.run(["choco", "install", "ninja", "-y"])
+        self.run(["choco", "install", "jq", "-y"])
+
+        if self.architecture in {"windows_amd64_rtools", "windows_amd64_mingw"}:
+            root = Path("C:/rtools42/x86_64-w64-mingw32.static.posix/bin")
+            for source, destination in (
+                ("gcc.exe", "x86_64-w64-mingw32-gcc.exe"),
+                ("g++.exe", "x86_64-w64-mingw32-g++.exe"),
+                ("gfortran.exe", "x86_64-w64-mingw32-gfortran.exe"),
+            ):
+                shutil.copy2(root / source, root / destination)
+            zstd = Path("C:/rtools42/usr/bin/zstd.exe")
+            if zstd.exists():
+                zstd.rename(zstd.with_name("zstd-rtools.exe"))
+
+        self.run(["make", "configure_ci"], extra_env=self.build_environment())
+        self.install_extra_vcpkg_dependencies()
+
+    def setup_wasm(self) -> None:
+        self.install_vcpkg()
+        if tool_enabled(self.value("CI_EXTRA_TOOLCHAINS"), "downgraded_aws_cli"):
+            self.run(["curl", "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.35.zip", "-o", "awscliv2.zip"])
+            self.run(["unzip", "-q", "awscliv2.zip"])
+            self.run(["sudo", "./aws/install", "--update"])
+            self.run(["aws", "--version"])
+        self.run_with_retry(
+            ["make", "configure_ci"],
+            extra_env={"DUCKDB_GIT_VERSION": self.value("CI_DUCKDB_VERSION")},
+        )
+        self.install_extra_vcpkg_dependencies()
+
+    def setup(self) -> None:
+        self.inject_extension_config()
+        getattr(self, f"setup_{self.platform}")()
+
+    def build_environment(self) -> dict[str, str]:
+        is_rtools = self.architecture in {"windows_amd64_rtools", "windows_amd64_mingw"}
+        return {
+            "DUCKDB_PLATFORM": self.architecture,
+            "DUCKDB_PLATFORM_RTOOLS": "1" if is_rtools else "0",
+            "DUCKDB_GIT_VERSION": self.value("CI_DUCKDB_VERSION"),
+            "EXTENSION_NAME": self.required("CI_EXTENSION_NAME"),
+            "EXTENSION_CANONICAL": self.value("CI_EXTENSION_CANONICAL"),
+            "ENABLE_EXTENSION_AUTOINSTALL": "1",
+            "ENABLE_EXTENSION_AUTOLOADING": "1",
+        }
+
+    def docker_arguments(self) -> list[str]:
+        return [
+            "docker",
+            "run",
+            "--env-file=docker_env.txt",
+            "-v",
+            f"{self.workspace}:/duckdb_build_dir",
+            "-v",
+            f"{self.workspace / '.ccache'}:/ccache_dir",
+            f"duckdb/{self.architecture}",
+        ]
+
+    def create_docker_environment(self) -> None:
+        values = {
+            "VCPKG_BINARY_SOURCES": self.value("VCPKG_BINARY_SOURCES"),
+            "USE_MERGED_VCPKG_MANIFEST": self.value("USE_MERGED_VCPKG_MANIFEST"),
+            "AWS_ACCESS_KEY_ID": self.value("AWS_ACCESS_KEY_ID"),
+            "AWS_SECRET_ACCESS_KEY": self.value("AWS_SECRET_ACCESS_KEY"),
+            "AWS_ENDPOINT_URL": self.value("AWS_ENDPOINT_URL"),
+            "AWS_DEFAULT_REGION": self.value("AWS_DEFAULT_REGION"),
+            "AWS_REQUEST_CHECKSUM_CALCULATION": "when_required",
+            "VCPKG_TARGET_TRIPLET": self.value("VCPKG_TARGET_TRIPLET"),
+            "VCPKG_OVERLAY_TRIPLETS": f"/duckdb_build_dir/{self.value('CI_VCPKG_OVERLAY_TRIPLETS')}",
+            "VCPKG_OVERLAY_PORTS": f"/duckdb_build_dir/{self.value('CI_VCPKG_OVERLAY_PORTS')}",
+            "CUDAARCHS": self.value("CI_CUDA_ARCHS"),
+            "VCPKG_CUDA_VERSION": self.value("CI_CUDA_VERSION"),
+            "BUILD_SHELL": "1" if self.enabled("CI_BUILD_DUCKDB_SHELL") else "0",
+            "OPENSSL_ROOT_DIR": f"/duckdb_build_dir/build/{self.value('CI_BUILD_TYPE')}/vcpkg_installed/{self.value('VCPKG_TARGET_TRIPLET')}",
+            "OPENSSL_DIR": f"/duckdb_build_dir/build/{self.value('CI_BUILD_TYPE')}/vcpkg_installed/{self.value('VCPKG_TARGET_TRIPLET')}",
+            "OPENSSL_USE_STATIC_LIBS": "true",
+            "DUCKDB_PLATFORM": self.architecture,
+            "DUCKDB_GIT_VERSION": self.value("CI_DUCKDB_VERSION"),
+            "ENABLE_EXTENSION_AUTOINSTALL": "1",
+            "ENABLE_EXTENSION_AUTOLOADING": "1",
+            "EXTENSION_NAME": self.required("CI_EXTENSION_NAME"),
+            "EXTENSION_CANONICAL": self.value("CI_EXTENSION_CANONICAL"),
+            "LINUX_CI_IN_DOCKER": "1",
+            "GITHUB_ACTIONS": "true",
+            "CI": "true",
+            "CCACHE_MAXSIZE": "5G",
+            "SUBSET_EXTENSIONS_TESTS": self.value("CI_EXTENSIONS_TEST_SELECTION"),
+        }
+        values.update(test_environment(self.value("CI_TEST_CONFIG", "{}")))
+        with (self.workspace / "docker_env.txt").open("w", encoding="utf-8") as handle:
+            for key, value in values.items():
+                if "\n" in value:
+                    raise ValueError(f"Docker environment value {key} contains a newline")
+                handle.write(f"{key}={value}\n")
+
+    def build_linux(self) -> None:
+        self.run(
+            [
+                "docker",
+                "build",
+                "--build-arg",
+                f"vcpkg_url={self.required('CI_VCPKG_URL')}",
+                "--build-arg",
+                f"vcpkg_commit={self.required('CI_VCPKG_COMMIT')}",
+                "--build-arg",
+                f"extra_toolchains=;{self.value('CI_EXTRA_TOOLCHAINS').strip(';')};",
+                "--build-arg",
+                f"cuda_version={self.value('CI_CUDA_VERSION')}",
+                "-t",
+                f"duckdb/{self.architecture}",
+                str(self.workspace / "extension-ci-tools" / "docker" / self.architecture),
+            ]
+        )
+        self.create_docker_environment()
+        self.install_extra_vcpkg_dependencies(docker=True)
+        docker = self.docker_arguments()
+        self.run_with_retry([*docker, "make", "configure_ci"])
+        self.run_with_retry([*docker, "make", self.required("CI_BUILD_TYPE")])
+        post_build = self.value("CI_POST_BUILD_COMMAND")
+        if post_build:
+            self.run(post_build, shell=True, extra_env={"MATRIX_RUNNER": self.value("CI_MATRIX_RUNNER")})
+
+    def build_macos(self) -> None:
+        self.run(["make", self.required("CI_BUILD_TYPE")], extra_env=self.build_environment())
+
+    def build_windows(self) -> None:
+        environment = self.build_environment()
+        environment["EXT_FLAGS"] = (
+            "-DCMAKE_C_COMPILER_LAUNCHER=ccache "
+            "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+        )
+        rtools = environment["DUCKDB_PLATFORM_RTOOLS"] == "1"
+        commands = ["setlocal EnableDelayedExpansion"]
+        if not rtools:
+            target = {"windows_amd64": "vcvars64.bat", "windows_arm64": "vcvarsarm64.bat"}.get(self.architecture)
+            if target:
+                commands.append(
+                    f'if exist "C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise\\VC\\Auxiliary\\Build\\{target}" '
+                    f'(call "C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise\\VC\\Auxiliary\\Build\\{target}") '
+                    f'else (call "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\{target}")'
+                )
+            commands.append('if exist "C:\\Program Files\\Git\\usr\\bin\\link.exe" move "C:\\Program Files\\Git\\usr\\bin\\link.exe" "C:\\Program Files\\Git\\usr\\bin\\link-git.exe"')
+        commands.append(f"make {self.required('CI_BUILD_TYPE')}")
+        self.run(["cmd.exe", "/d", "/s", "/c", " && ".join(commands)], extra_env=environment)
+
+    def build_wasm(self) -> None:
+        self.run_with_retry(["make", self.architecture], extra_env=self.build_environment())
+
+    def build(self) -> None:
+        getattr(self, f"build_{self.platform}")()
+
+    def test(self) -> None:
+        if self.enabled("CI_SKIP_TESTS"):
+            print("Tests skipped by workflow input.")
+            return
+        environment = self.build_environment()
+        environment["SUBSET_EXTENSIONS_TESTS"] = self.value("CI_EXTENSIONS_TEST_SELECTION")
+        environment.update(test_environment(self.value("CI_TEST_CONFIG", "{}")))
+        target = f"test_{self.required('CI_BUILD_TYPE')}"
+
+        if self.platform == "linux":
+            if self.architecture == "linux_arm64":
+                print("Tests are not supported for linux_arm64.")
+                return
+            self.run([*self.docker_arguments(), "make", target])
+            environment["LINUX_CI_IN_DOCKER"] = "0"
+            self.run(["make", target], extra_env=environment)
+        elif self.platform == "macos":
+            if self.value("CI_OSX_BUILD_ARCH") != "arm64":
+                print("Tests run only on the native macOS arm64 build.")
+                return
+            self.run(["make", target], extra_env=environment)
+        elif self.platform == "windows":
+            self.run(["make", target], extra_env=environment)
+        else:
+            print("The Wasm distribution job has no test target.")
+
+    def artifact_path(self) -> str:
+        all_extensions = self.enabled("CI_UPLOAD_ALL_EXTENSIONS")
+        extension = self.required("CI_EXTENSION_NAME")
+        if self.platform == "wasm":
+            base = f"build/{self.architecture}"
+            return (
+                f"{base}/repository/**/*.duckdb_extension.wasm"
+                if all_extensions
+                else f"{base}/extension/{extension}/{extension}.duckdb_extension.wasm"
+            )
+        base = f"build/{self.required('CI_BUILD_TYPE')}"
+        return (
+            f"{base}/repository/**/*.duckdb_extension"
+            if all_extensions
+            else f"{base}/extension/{extension}/{extension}.duckdb_extension"
+        )
+
+    def print_rust_logs(self) -> None:
+        if not self.enabled("CI_RUST_LOGS") or not self.enabled("CI_HAS_RUST"):
+            return
+        pattern = self.workspace / "build" / self.required("CI_BUILD_TYPE") / "rust" / "src" / "**" / "*build-*.log"
+        logs = sorted(glob.glob(str(pattern), recursive=True))
+        if not logs:
+            print(f"No Rust build logs found under {pattern.parent}")
+            return
+        for filename in logs:
+            print(f"Printing logs for file {filename}")
+            print(Path(filename).read_text(encoding="utf-8", errors="replace"))
+            print(f"Done printing logs for file {filename}")
+
+    def upload(self) -> None:
+        path = self.artifact_path()
+        matches = glob.glob(str(self.workspace / path), recursive=True)
+        if not matches:
+            raise FileNotFoundError(f"no artifact matched {path}")
+        name = (
+            f"{self.required('CI_EXTENSION_NAME')}-{self.value('CI_DUCKDB_VERSION')}-extension-"
+            f"{self.architecture}{self.value('CI_ARTIFACT_POSTFIX')}"
+        )
+        self.append_github_file("GITHUB_OUTPUT", "artifact_path", path)
+        self.append_github_file("GITHUB_OUTPUT", "artifact_name", name)
+        self.print_rust_logs()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("phase", choices=("checkout", "setup", "build", "test", "upload"))
+    args = parser.parse_args()
+    runner = PhaseRunner()
+    getattr(runner, args.phase)()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -432,11 +432,18 @@ class PhaseRunner:
         if not rtools:
             target = {"windows_amd64": "vcvars64.bat", "windows_arm64": "vcvarsarm64.bat"}.get(self.architecture)
             if target:
-                commands.append(
-                    f'if exist "C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise\\VC\\Auxiliary\\Build\\{target}" '
-                    f'(call "C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise\\VC\\Auxiliary\\Build\\{target}") '
-                    f'else (call "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\{target}")'
+                vs18_vcvars = (
+                    "C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise"
+                    f"\\VC\\Auxiliary\\Build\\{target}"
                 )
+                vs2022_vcvars = (
+                    "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise"
+                    f"\\VC\\Auxiliary\\Build\\{target}"
+                )
+                vcvars = vs18_vcvars if os.path.isfile(vs18_vcvars) else vs2022_vcvars
+                # vcvars changes this cmd.exe process's environment, so the build
+                # must remain in the same shell invocation.
+                commands.append(f'call "{vcvars}"')
             # Keep this optional rename separate from the &&-chained build command.
             # Otherwise cmd.exe treats the build as part of the IF body and skips it
             # when Git's link.exe is not present.

--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -12,6 +12,7 @@ import glob
 import json
 import os
 from pathlib import Path
+import shlex
 import shutil
 import subprocess
 import sys
@@ -19,6 +20,10 @@ from typing import Mapping, Sequence
 
 
 TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def format_command(command: Sequence[str] | str) -> str:
+    return command if isinstance(command, str) else shlex.join(command)
 
 
 def is_true(value: str | None) -> bool:
@@ -84,8 +89,7 @@ class PhaseRunner:
         environment = self.env.copy()
         if extra_env:
             environment.update(extra_env)
-        printable = command if isinstance(command, str) else " ".join(command)
-        print(f"+ {printable}", flush=True)
+        print(f"+ {format_command(command)}", flush=True)
         options = {
             "check": True,
             "cwd": cwd or self.workspace,
@@ -528,7 +532,15 @@ def main() -> None:
     parser.add_argument("phase", choices=("checkout", "setup", "build", "test", "upload"))
     args = parser.parse_args()
     runner = PhaseRunner()
-    getattr(runner, args.phase)()
+    try:
+        getattr(runner, args.phase)()
+    except subprocess.CalledProcessError as error:
+        print(
+            f"error: command failed with exit code {error.returncode}: "
+            f"{format_command(error.cmd)}",
+            file=sys.stderr,
+        )
+        raise SystemExit(error.returncode) from None
 
 
 if __name__ == "__main__":

--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -433,7 +433,16 @@ class PhaseRunner:
                     f'(call "C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise\\VC\\Auxiliary\\Build\\{target}") '
                     f'else (call "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\{target}")'
                 )
-            commands.append('if exist "C:\\Program Files\\Git\\usr\\bin\\link.exe" move "C:\\Program Files\\Git\\usr\\bin\\link.exe" "C:\\Program Files\\Git\\usr\\bin\\link-git.exe"')
+            # Keep this optional rename separate from the &&-chained build command.
+            # Otherwise cmd.exe treats the build as part of the IF body and skips it
+            # when Git's link.exe is not present.
+            self.run(
+                'if exist "C:\\Program Files\\Git\\usr\\bin\\link.exe" '
+                'move "C:\\Program Files\\Git\\usr\\bin\\link.exe" '
+                '"C:\\Program Files\\Git\\usr\\bin\\link-git.exe"',
+                shell=True,
+                extra_env=environment,
+            )
         commands.append(f"make {self.required('CI_BUILD_TYPE')}")
         # cmd.exe does not understand the C-runtime quote escaping used for argument lists.
         self.run(" && ".join(commands), shell=True, extra_env=environment)

--- a/scripts/test_ci_phase.py
+++ b/scripts/test_ci_phase.py
@@ -1,8 +1,12 @@
+from contextlib import redirect_stderr
+import io
 import os
 from pathlib import Path
+import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -10,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from ci_phase import (  # noqa: E402
     PhaseRunner,
     extra_dependencies,
+    main,
     is_true,
     test_environment,
     tool_enabled,
@@ -113,6 +118,33 @@ class CIPhaseTest(unittest.TestCase):
             self.assertEqual(len(runner.commands), 2)
             self.assertEqual(runner.commands[0][0][-2:], ["make", "test_release"])
             self.assertEqual(runner.commands[1][0], ["make", "test_release"])
+
+    def test_failed_phase_command_exits_concisely_for_list_and_shell_commands(self):
+        commands = (
+            (["make", "test release"], "make 'test release'"),
+            ("make test_release", "make test_release"),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            environment = self.environment(directory)
+            for command, printable in commands:
+                with self.subTest(command=command):
+                    error = subprocess.CalledProcessError(2, command)
+                    stderr = io.StringIO()
+                    with (
+                        mock.patch.dict(os.environ, environment, clear=True),
+                        mock.patch.object(sys, "argv", ["ci_phase.py", "test"]),
+                        mock.patch.object(PhaseRunner, "test", side_effect=error),
+                        redirect_stderr(stderr),
+                    ):
+                        with self.assertRaises(SystemExit) as raised:
+                            main()
+
+                    self.assertEqual(raised.exception.code, 2)
+                    self.assertEqual(
+                        stderr.getvalue(),
+                        f"error: command failed with exit code 2: {printable}\n",
+                    )
+                    self.assertNotIn("Traceback", stderr.getvalue())
 
     def test_linux_build_uses_action_cache_directory_and_five_gigabyte_limit(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test_ci_phase.py
+++ b/scripts/test_ci_phase.py
@@ -133,23 +133,32 @@ class CIPhaseTest(unittest.TestCase):
             configure = runner.commands[-2][0]
             self.assertIn(f"{Path(directory).resolve() / '.ccache'}:/ccache_dir", configure)
 
-    def test_windows_build_uses_shell_string_for_quoted_paths(self):
+    def test_windows_build_separates_optional_linker_rename(self):
         with tempfile.TemporaryDirectory() as directory:
             env = self.environment(directory, "windows", "windows_amd64")
             runner = RecordingRunner(env)
             runner.build_windows()
 
-            self.assertEqual(len(runner.commands), 1)
-            command, options = runner.commands[0]
-            self.assertIsInstance(command, str)
-            self.assertTrue(options["shell"])
+            self.assertEqual(len(runner.commands), 2)
+            rename_command, rename_options = runner.commands[0]
+            self.assertIsInstance(rename_command, str)
+            self.assertTrue(rename_options["shell"])
+            self.assertIn(
+                'if exist "C:\\Program Files\\Git\\usr\\bin\\link.exe" move',
+                rename_command,
+            )
+
+            build_command, build_options = runner.commands[1]
+            self.assertIsInstance(build_command, str)
+            self.assertTrue(build_options["shell"])
             self.assertIn(
                 'call "C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise'
                 '\\VC\\Auxiliary\\Build\\vcvars64.bat"',
-                command,
+                build_command,
             )
-            self.assertNotIn('\\"', command)
-            self.assertTrue(command.endswith(" && make release"))
+            self.assertNotIn('\\"', build_command)
+            self.assertNotIn("link.exe", build_command)
+            self.assertTrue(build_command.endswith(" && make release"))
 
     def test_upload_writes_outputs_and_validates_artifact(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test_ci_phase.py
+++ b/scripts/test_ci_phase.py
@@ -1,0 +1,159 @@
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from ci_phase import (  # noqa: E402
+    PhaseRunner,
+    extra_dependencies,
+    is_true,
+    test_environment,
+    tool_enabled,
+)
+
+
+class RecordingRunner(PhaseRunner):
+    def __init__(self, environ):
+        super().__init__(environ)
+        self.commands = []
+
+    def run(self, command, **kwargs):
+        self.commands.append((command, kwargs))
+
+    def run_with_retry(self, command, **kwargs):
+        self.commands.append((command, {**kwargs, "retry": True}))
+
+
+class CIPhaseTest(unittest.TestCase):
+    def environment(self, workspace, platform="linux", architecture="linux_amd64"):
+        return {
+            "CI_PLATFORM": platform,
+            "DUCKDB_PLATFORM": architecture,
+            "GITHUB_WORKSPACE": str(workspace),
+            "CI_EXTENSION_NAME": "quack",
+            "CI_EXTENSION_CANONICAL": "",
+            "CI_DUCKDB_VERSION": "v1.2.3",
+            "CI_BUILD_TYPE": "release",
+            "CI_TEST_CONFIG": "{}",
+            "CI_EXTENSIONS_TEST_SELECTION": "regular",
+        }
+
+    def test_boolean_and_toolchain_parsing(self):
+        self.assertTrue(is_true("true"))
+        self.assertTrue(is_true("1"))
+        self.assertFalse(is_true("false"))
+        self.assertTrue(tool_enabled("rust;go", "go"))
+        self.assertFalse(tool_enabled("fortran", "go"))
+
+    def test_json_inputs(self):
+        self.assertEqual(
+            test_environment('{"test_env_variables":{"TOKEN":12,"ENABLED":true}}'),
+            {"TOKEN": "12", "ENABLED": "true"},
+        )
+        self.assertEqual(
+            extra_dependencies('{"linux_amd64":["openssl","zlib"]}', "linux_amd64"),
+            ["openssl", "zlib"],
+        )
+        self.assertEqual(extra_dependencies("{}", "linux_amd64"), [])
+
+    def test_checkout_runs_only_requested_operations(self):
+        with tempfile.TemporaryDirectory() as directory:
+            env = self.environment(directory)
+            env.update(
+                {
+                    "CI_DUCKDB_GIT_REPOSITORY": "duckdb/duckdb-fork",
+                    "CI_EXTENSION_TAG": "v2.0.0",
+                    "CI_DUCKDB_TAG": "v1.2.3-test",
+                }
+            )
+            runner = RecordingRunner(env)
+            runner.checkout()
+            commands = [command for command, _ in runner.commands]
+            self.assertEqual(
+                commands,
+                [
+                    ["make", "set_duckdb_repository"],
+                    ["make", "set_duckdb_version"],
+                    ["git", "tag", "v2.0.0"],
+                    ["make", "set_duckdb_tag"],
+                ],
+            )
+
+    def test_artifact_paths_for_native_and_wasm(self):
+        with tempfile.TemporaryDirectory() as directory:
+            native = RecordingRunner(self.environment(directory))
+            self.assertEqual(
+                native.artifact_path(),
+                "build/release/extension/quack/quack.duckdb_extension",
+            )
+            wasm_env = self.environment(directory, "wasm", "wasm_eh")
+            wasm_env["CI_UPLOAD_ALL_EXTENSIONS"] = "true"
+            wasm = RecordingRunner(wasm_env)
+            self.assertEqual(
+                wasm.artifact_path(),
+                "build/wasm_eh/repository/**/*.duckdb_extension.wasm",
+            )
+
+    def test_skip_test_does_not_execute_commands(self):
+        with tempfile.TemporaryDirectory() as directory:
+            env = self.environment(directory)
+            env["CI_SKIP_TESTS"] = "true"
+            runner = RecordingRunner(env)
+            runner.test()
+            self.assertEqual(runner.commands, [])
+
+    def test_linux_test_runs_inside_and_outside_docker(self):
+        with tempfile.TemporaryDirectory() as directory:
+            runner = RecordingRunner(self.environment(directory))
+            runner.test()
+            self.assertEqual(len(runner.commands), 2)
+            self.assertEqual(runner.commands[0][0][-2:], ["make", "test_release"])
+            self.assertEqual(runner.commands[1][0], ["make", "test_release"])
+
+    def test_linux_build_uses_action_cache_directory_and_five_gigabyte_limit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            env = self.environment(directory)
+            env.update(
+                {
+                    "CI_VCPKG_URL": "https://github.com/microsoft/vcpkg.git",
+                    "CI_VCPKG_COMMIT": "abc123",
+                    "CI_VCPKG_OVERLAY_PORTS": "extension-ci-tools/vcpkg_ports",
+                    "CI_VCPKG_OVERLAY_TRIPLETS": "extension-ci-tools/toolchains",
+                    "CI_CUDA_VERSION": "13",
+                }
+            )
+            runner = RecordingRunner(env)
+            runner.build_linux()
+            docker_environment = Path(directory, "docker_env.txt").read_text(encoding="utf-8")
+            self.assertIn("CCACHE_MAXSIZE=5G\n", docker_environment)
+            configure = runner.commands[-2][0]
+            self.assertIn(f"{Path(directory).resolve() / '.ccache'}:/ccache_dir", configure)
+
+    def test_upload_writes_outputs_and_validates_artifact(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            artifact = workspace / "build/release/extension/quack/quack.duckdb_extension"
+            artifact.parent.mkdir(parents=True)
+            artifact.touch()
+            output = workspace / "github-output"
+            env = self.environment(workspace)
+            env["GITHUB_OUTPUT"] = str(output)
+            runner = RecordingRunner(env)
+            runner.upload()
+            values = output.read_text(encoding="utf-8")
+            self.assertIn("artifact_path=build/release/extension/quack/quack.duckdb_extension", values)
+            self.assertIn("artifact_name=quack-v1.2.3-extension-linux_amd64", values)
+
+    def test_upload_fails_when_artifact_is_missing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            runner = RecordingRunner(self.environment(directory))
+            with self.assertRaises(FileNotFoundError):
+                runner.upload()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ci_phase.py
+++ b/scripts/test_ci_phase.py
@@ -133,6 +133,24 @@ class CIPhaseTest(unittest.TestCase):
             configure = runner.commands[-2][0]
             self.assertIn(f"{Path(directory).resolve() / '.ccache'}:/ccache_dir", configure)
 
+    def test_windows_build_uses_shell_string_for_quoted_paths(self):
+        with tempfile.TemporaryDirectory() as directory:
+            env = self.environment(directory, "windows", "windows_amd64")
+            runner = RecordingRunner(env)
+            runner.build_windows()
+
+            self.assertEqual(len(runner.commands), 1)
+            command, options = runner.commands[0]
+            self.assertIsInstance(command, str)
+            self.assertTrue(options["shell"])
+            self.assertIn(
+                'call "C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise'
+                '\\VC\\Auxiliary\\Build\\vcvars64.bat"',
+                command,
+            )
+            self.assertNotIn('\\"', command)
+            self.assertTrue(command.endswith(" && make release"))
+
     def test_upload_writes_outputs_and_validates_artifact(self):
         with tempfile.TemporaryDirectory() as directory:
             workspace = Path(directory)

--- a/scripts/test_ci_phase.py
+++ b/scripts/test_ci_phase.py
@@ -165,32 +165,37 @@ class CIPhaseTest(unittest.TestCase):
             configure = runner.commands[-2][0]
             self.assertIn(f"{Path(directory).resolve() / '.ccache'}:/ccache_dir", configure)
 
-    def test_windows_build_separates_optional_linker_rename(self):
+    def test_windows_build_selects_vcvars_before_running_shell(self):
         with tempfile.TemporaryDirectory() as directory:
             env = self.environment(directory, "windows", "windows_amd64")
-            runner = RecordingRunner(env)
-            runner.build_windows()
+            for has_vs18, version in ((True, "18"), (False, "2022")):
+                with self.subTest(has_vs18=has_vs18):
+                    runner = RecordingRunner(env)
+                    with mock.patch("ci_phase.os.path.isfile", return_value=has_vs18):
+                        runner.build_windows()
 
-            self.assertEqual(len(runner.commands), 2)
-            rename_command, rename_options = runner.commands[0]
-            self.assertIsInstance(rename_command, str)
-            self.assertTrue(rename_options["shell"])
-            self.assertIn(
-                'if exist "C:\\Program Files\\Git\\usr\\bin\\link.exe" move',
-                rename_command,
-            )
+                    self.assertEqual(len(runner.commands), 2)
+                    rename_command, rename_options = runner.commands[0]
+                    self.assertIsInstance(rename_command, str)
+                    self.assertTrue(rename_options["shell"])
+                    self.assertIn(
+                        'if exist "C:\\Program Files\\Git\\usr\\bin\\link.exe" move',
+                        rename_command,
+                    )
 
-            build_command, build_options = runner.commands[1]
-            self.assertIsInstance(build_command, str)
-            self.assertTrue(build_options["shell"])
-            self.assertIn(
-                'call "C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise'
-                '\\VC\\Auxiliary\\Build\\vcvars64.bat"',
-                build_command,
-            )
-            self.assertNotIn('\\"', build_command)
-            self.assertNotIn("link.exe", build_command)
-            self.assertTrue(build_command.endswith(" && make release"))
+                    build_command, build_options = runner.commands[1]
+                    self.assertIsInstance(build_command, str)
+                    self.assertTrue(build_options["shell"])
+                    self.assertIn(
+                        f'call "C:\\Program Files\\Microsoft Visual Studio\\{version}'
+                        '\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"',
+                        build_command,
+                    )
+                    self.assertNotIn('\\"', build_command)
+                    self.assertNotIn("if exist", build_command)
+                    self.assertNotIn(" else ", build_command)
+                    self.assertNotIn("link.exe", build_command)
+                    self.assertTrue(build_command.endswith(" && make release"))
 
     def test_upload_writes_outputs_and_validates_artifact(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
### Changes

- Reduce CI steps and use larger ccache size.
- Run CI job `Extensions template (C API)` with `osx_arm64` on namespace for increased coverage.

### CI steps

Reduced CI steps from 40 steps to 16 by grouping them together:

| Old workflow steps | New equivalent |
|---|---|
| Repository checkouts, DuckDB version/tag setup | `Checkout / …` and `Checkout / Prepare sources` |
| Platform tools, vcpkg, Docker, configuration | Platform actions and `Setup` |
| Docker/native compilation and post-build command | `Build` |
| Linux inside/outside tests, native macOS/Windows tests | `Test` |
| Conditional artifact selection, Rust logs, upload | `Upload / Prepare artifacts` and `Upload` |

The CI run is now:

<img width="848" height="723" alt="Screenshot 2026-08-07 at 14 14 27" src="https://github.com/user-attachments/assets/7e6081ee-6566-4f90-b43f-dc24898c53f9" />

### Validation

<details>
<summary>Codex compared an old and this PR's CI run</summary>

Semantically, the new run executes the equivalent CI work for every comparable job. It is not a literal step-for-step match because many legacy steps were consolidated into Python-driven phases.

Key findings:

- All 26 comparable executed jobs succeeded in both the [old run](https://github.com/duckdb/extension-ci-tools/actions/runs/29554965949) and [new run](https://github.com/duckdb/extension-ci-tools/actions/runs/31164599319).
- The new run is a strict coverage superset, adding:
  - Distribution phase-runner unit tests on Ubuntu
  - Distribution phase-runner unit tests on Windows
  - Custom-runner `osx_arm64` build/test/upload
- Excluding delta, all 15 old artifact names are present in the new run; the new run adds the custom-runner macOS artifact.

The command logs confirm the important underlying commands still ran: `make set_duckdb_version`, host and Docker `make configure_ci`, the platform build targets, Linux inside/outside `make test_release`, native macOS ARM and Windows tests, and artifact upload.

Important qualifications:

- `Test` appears successful on `linux_arm64`, `osx_amd64`, and Wasm, but performs no actual tests there. The old workflow also skipped tests for those targets, so coverage is equivalent, though the new UI is less explicit.
- Caching is intentionally different: the new workflow uses the ccache action consistently, a 5 GB compressed cache, and new keys with legacy restore fallbacks. The old Linux path used a manual 1 GB uncompressed cache.
- Wasm now sets up Python 3.11 to run the consolidated phase script.
- The Rust template source changed between runs (`0a839a…` → `abb7b2…`) because it tracks `main`; the C API and main template revisions were unchanged. Therefore artifact byte sizes are not a valid strict equivalence check.
- The new run’s overall failure is attributable to the ignored delta `linux_amd64` job. The remaining comparable CI and deploy dry run completed successfully.

Bottom line: functional build/test/upload coverage is preserved for the common matrix, and the new run adds coverage. The only material non-equivalence is operational—primarily caching and step consolidation—not lost CI validation.
</details>

I [tested](https://github.com/duckdb/duckdb/pull/24590) this new workflow in duckdb main on those extensions for all platforms/archs.