### PR TITLE
Strip trailing newline chars from docker env vars

### DIFF
--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -387,7 +387,8 @@ class PhaseRunner:
         values.update(test_environment(self.value("CI_TEST_CONFIG", "{}")))
         with (self.workspace / "docker_env.txt").open("w", encoding="utf-8") as handle:
             for key, value in values.items():
-                if "\n" in value:
+                value = value.rstrip("\r\n")
+                if "\n" in value or "\r" in value:
                     raise ValueError(f"Docker environment value {key} contains a newline")
                 handle.write(f"{key}={value}\n")
 


### PR DESCRIPTION
In [CI](https://github.com/duckdb/extension-ci-tools/actions/runs/31382191535/job/93437054365), I see an explicit newline after 
```
AWS_SECRET_ACCESS_KEY: ***

```
for `Extension template / linux_arm64` on main and that results in a failure:
```
Traceback (most recent call last):
  File "/home/runner/work/extension-ci-tools/extension-ci-tools/extension-ci-tools/scripts/ci_phase.py", line 554, in <module>
    main()
  File "/home/runner/work/extension-ci-tools/extension-ci-tools/extension-ci-tools/scripts/ci_phase.py", line 543, in main
    getattr(runner, args.phase)()
  File "/home/runner/work/extension-ci-tools/extension-ci-tools/extension-ci-tools/scripts/ci_phase.py", line 465, in build
    getattr(self, f"build_{self.platform}")()
  File "/home/runner/work/extension-ci-tools/extension-ci-tools/extension-ci-tools/scripts/ci_phase.py", line 412, in build_linux
    self.create_docker_environment()
  File "/home/runner/work/extension-ci-tools/extension-ci-tools/extension-ci-tools/scripts/ci_phase.py", line 391, in create_docker_environment
    raise ValueError(f"Docker environment value {key} contains a newline")
ValueError: Docker environment value AWS_SECRET_ACCESS_KEY contains a newline
Error: Process completed with exit code 1.
```

This PR strips trailing newlines from the env vars before passing them to docker.