### PR TITLE
Add workflow for build/test job split

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
     steps:
       - name: Compute matrix
         id: matrix
-        uses: duckdb/duckdb-ci/matrix@main
+        uses: duckdb/duckdb-ci/matrix@b04577afa9c044f98d6b14b0300ec7ed55c65a23 # main
         with:
           exclude_archs: ${{ inputs.exclude_archs }}
           opt_in_archs: ${{ inputs.opt_in_archs }}
@@ -164,7 +164,7 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
     steps:
       - name: Prepare sources
-        uses: duckdb/duckdb-ci/prepare-extension@main
+        uses: duckdb/duckdb-ci/prepare-extension@b04577afa9c044f98d6b14b0300ec7ed55c65a23 # main
         with:
           extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
           extension-ref: ${{ inputs.extension_ref }}
@@ -188,7 +188,7 @@ jobs:
       - name: Configure
         run: python3 extension-ci-tools/scripts/ci_phase.py setup
       - name: Build
-        uses: duckdb/duckdb-ci/build-duckdb@main
+        uses: duckdb/duckdb-ci/build-duckdb@b04577afa9c044f98d6b14b0300ec7ed55c65a23 # main
         with:
           build: python3 extension-ci-tools/scripts/ci_phase.py build
           test: python3 extension-ci-tools/scripts/ci_phase.py test
@@ -231,7 +231,7 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
     steps:
       - name: Prepare sources
-        uses: duckdb/duckdb-ci/prepare-extension@main
+        uses: duckdb/duckdb-ci/prepare-extension@b04577afa9c044f98d6b14b0300ec7ed55c65a23 # main
         with:
           extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
           extension-ref: ${{ inputs.extension_ref }}
@@ -262,7 +262,7 @@ jobs:
       - name: Configure
         run: python3 extension-ci-tools/scripts/ci_phase.py setup
       - name: Build
-        uses: duckdb/duckdb-ci/build-duckdb@main
+        uses: duckdb/duckdb-ci/build-duckdb@b04577afa9c044f98d6b14b0300ec7ed55c65a23 # main
         with:
           build: python3 extension-ci-tools/scripts/ci_phase.py build
           test: python3 extension-ci-tools/scripts/ci_phase.py test
@@ -310,7 +310,7 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - name: Prepare sources
-        uses: duckdb/duckdb-ci/prepare-extension@main
+        uses: duckdb/duckdb-ci/prepare-extension@b04577afa9c044f98d6b14b0300ec7ed55c65a23 # main
         with:
           extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
           extension-ref: ${{ inputs.extension_ref }}
@@ -366,7 +366,7 @@ jobs:
       - name: Configure
         run: python extension-ci-tools/scripts/ci_phase.py setup
       - name: Build
-        uses: duckdb/duckdb-ci/build-duckdb@main
+        uses: duckdb/duckdb-ci/build-duckdb@b04577afa9c044f98d6b14b0300ec7ed55c65a23 # main
         with:
           build: python extension-ci-tools/scripts/ci_phase.py build
           test: python extension-ci-tools/scripts/ci_phase.py test
@@ -409,7 +409,7 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
     steps:
       - name: Prepare sources
-        uses: duckdb/duckdb-ci/prepare-extension@main
+        uses: duckdb/duckdb-ci/prepare-extension@b04577afa9c044f98d6b14b0300ec7ed55c65a23 # main
         with:
           extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
           extension-ref: ${{ inputs.extension_ref }}
@@ -446,7 +446,7 @@ jobs:
       - name: Configure
         run: python3 extension-ci-tools/scripts/ci_phase.py setup
       - name: Build
-        uses: duckdb/duckdb-ci/build-duckdb@main
+        uses: duckdb/duckdb-ci/build-duckdb@b04577afa9c044f98d6b14b0300ec7ed55c65a23 # main
         with:
           build: python3 extension-ci-tools/scripts/ci_phase.py build
           test: python3 extension-ci-tools/scripts/ci_phase.py test
@@ -486,7 +486,7 @@ jobs:
       CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
     steps:
       - name: Prepare sources
-        uses: duckdb/duckdb-ci/prepare-extension@main
+        uses: duckdb/duckdb-ci/prepare-extension@b04577afa9c044f98d6b14b0300ec7ed55c65a23 # main
         with:
           extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
           extension-ref: ${{ inputs.extension_ref }}
@@ -528,7 +528,7 @@ jobs:
       CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
     steps:
       - name: Prepare sources
-        uses: duckdb/duckdb-ci/prepare-extension@main
+        uses: duckdb/duckdb-ci/prepare-extension@b04577afa9c044f98d6b14b0300ec7ed55c65a23 # main
         with:
           extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
           extension-ref: ${{ inputs.extension_ref }}
@@ -581,7 +581,7 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - name: Prepare sources
-        uses: duckdb/duckdb-ci/prepare-extension@main
+        uses: duckdb/duckdb-ci/prepare-extension@b04577afa9c044f98d6b14b0300ec7ed55c65a23 # main
         with:
           extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
           extension-ref: ${{ inputs.extension_ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
         with:
           extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
           extension-ref: ${{ inputs.extension_ref }}
-          duckdb-repository: ${{ inputs.duckdb_repository != '' && inputs.duckdb_repository || 'duckdb/duckdb' }}
+          duckdb-repository: ${{ inputs.duckdb_repository }}
           duckdb-ref: ${{ inputs.duckdb_version }}
           duckdb-sha: ${{ inputs.duckdb_version }}
       - name: Checkout extension-ci-tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
       CI_EXTENSION_NAME: ${{ matrix.artifact_prefix }}
       CI_ARTIFACT_NAME: ${{ matrix.artifact_name }}
       CI_EXTENSION_CONFIG_PATHS: ${{ toJSON(matrix.extension_config_paths) }}
-      CI_EXTRA_TOOLCHAINS: ${{ matrix.toolchain }}
+      CI_EXTRA_TOOLCHAINS: ${{ format('{0};{1}', matrix.toolchain, matrix.extra_toolchains) }}
       CI_HAS_RUST: ${{ matrix.toolchain == 'rust' }}
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
@@ -221,7 +221,7 @@ jobs:
       CI_EXTENSION_NAME: ${{ matrix.artifact_prefix }}
       CI_ARTIFACT_NAME: ${{ matrix.artifact_name }}
       CI_EXTENSION_CONFIG_PATHS: ${{ toJSON(matrix.extension_config_paths) }}
-      CI_EXTRA_TOOLCHAINS: ${{ matrix.toolchain }}
+      CI_EXTRA_TOOLCHAINS: ${{ format('{0};{1}', matrix.toolchain, matrix.extra_toolchains) }}
       CI_HAS_RUST: ${{ matrix.toolchain == 'rust' }}
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
@@ -293,7 +293,7 @@ jobs:
       CI_EXTENSION_NAME: ${{ matrix.artifact_prefix }}
       CI_ARTIFACT_NAME: ${{ matrix.artifact_name }}
       CI_EXTENSION_CONFIG_PATHS: ${{ toJSON(matrix.extension_config_paths) }}
-      CI_EXTRA_TOOLCHAINS: ${{ matrix.toolchain }}
+      CI_EXTRA_TOOLCHAINS: ${{ format('{0};{1}', matrix.toolchain, matrix.extra_toolchains) }}
       CI_HAS_RUST: ${{ matrix.toolchain == 'rust' }}
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
@@ -399,7 +399,7 @@ jobs:
       CI_EXTENSION_NAME: ${{ matrix.artifact_prefix }}
       CI_ARTIFACT_NAME: ${{ matrix.artifact_name }}
       CI_EXTENSION_CONFIG_PATHS: ${{ toJSON(matrix.extension_config_paths) }}
-      CI_EXTRA_TOOLCHAINS: ${{ matrix.toolchain }}
+      CI_EXTRA_TOOLCHAINS: ${{ format('{0};{1}', matrix.toolchain, matrix.extra_toolchains) }}
       CI_HAS_RUST: ${{ matrix.toolchain == 'rust' }}
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,13 +333,6 @@ jobs:
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: x86_64-pc-windows-gnu
-      - name: Setup Rtools
-        if: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw' }}
-        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
-        with:
-          r-version: devel
-          update-rtools: true
-          rtools-version: "42"
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
@@ -347,6 +340,13 @@ jobs:
           evict-old-files: job
           key: build-${{ matrix.artifact_name }}-${{ inputs.duckdb_version }}
           save: ${{ inputs.save_cache }}
+      - name: Setup Rtools
+        if: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw' }}
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+        with:
+          r-version: devel
+          update-rtools: true
+          rtools-version: "42"
       - name: Configure short vcpkg path
         shell: pwsh
         run: |
@@ -541,6 +541,8 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
+      - name: Install build prerequisites
+        run: brew install ninja
       - name: Download extension artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -566,6 +568,8 @@ jobs:
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
       CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
+      CC: ${{ matrix.duckdb_arch == 'windows_amd64_mingw' && 'gcc' || 'cl' }}
+      CXX: ${{ matrix.duckdb_arch == 'windows_amd64_mingw' && 'g++' || 'cl' }}
     steps:
       - name: Configure line endings
         shell: bash
@@ -590,6 +594,15 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
+      - name: Setup Rtools
+        if: ${{ matrix.duckdb_arch == 'windows_amd64_mingw' }}
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+        with:
+          r-version: devel
+          update-rtools: true
+          rtools-version: "42"
+      - name: Install build prerequisites
+        run: choco install ninja -y
       - name: Download extension artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
           groups: ${{ inputs.groups }}
 
   build_linux:
-    name: Build Linux (${{ matrix.artifact_prefix }}, ${{ matrix.duckdb_arch }})
+    name: Build Linux (${{ matrix.group_name }}, ${{ matrix.duckdb_arch }})
     needs: matrix
     if: ${{ needs.matrix.outputs.build_linux != '' && needs.matrix.outputs.build_linux != '{"include":[]}' }}
     runs-on: ${{ matrix.runner }}
@@ -202,7 +202,7 @@ jobs:
           if-no-files-found: error
 
   build_macos:
-    name: Build macOS (${{ matrix.artifact_prefix }}, ${{ matrix.duckdb_arch }})
+    name: Build macOS (${{ matrix.group_name }}, ${{ matrix.duckdb_arch }})
     needs: matrix
     if: ${{ needs.matrix.outputs.build_macos != '' }}
     runs-on: ${{ matrix.runner }}
@@ -271,7 +271,7 @@ jobs:
           if-no-files-found: error
 
   build_windows:
-    name: Build Windows (${{ matrix.artifact_prefix }}, ${{ matrix.duckdb_arch }})
+    name: Build Windows (${{ matrix.group_name }}, ${{ matrix.duckdb_arch }})
     needs: matrix
     if: ${{ needs.matrix.outputs.build_windows != '' }}
     runs-on: ${{ matrix.runner }}
@@ -369,7 +369,7 @@ jobs:
           if-no-files-found: error
 
   build_wasm:
-    name: Build Wasm (${{ matrix.artifact_prefix }}, ${{ matrix.duckdb_arch }})
+    name: Build Wasm (${{ matrix.group_name }}, ${{ matrix.duckdb_arch }})
     needs: matrix
     if: ${{ needs.matrix.outputs.build_wasm != '' }}
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,18 +208,6 @@ jobs:
           name: ${{ steps.artifact.outputs.artifact_name }}
           path: ${{ steps.artifact.outputs.artifact_path }}
           if-no-files-found: error
-      - name: Prepare test support
-        if: ${{ !inputs.skip_tests && matrix.duckdb_arch != 'linux_arm64' }}
-        id: test-support
-        run: python3 extension-ci-tools/scripts/ci_phase.py bundle_test_support
-      - name: Upload test support
-        if: ${{ !inputs.skip_tests && matrix.duckdb_arch != 'linux_arm64' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ matrix.artifact_name }}-test-support
-          path: ${{ steps.test-support.outputs.test_support_path }}
-          retention-days: 1
-          if-no-files-found: error
 
   build_macos:
     name: Build macOS (${{ matrix.artifact_prefix }}, ${{ matrix.duckdb_arch }})
@@ -287,18 +275,6 @@ jobs:
         with:
           name: ${{ steps.artifact.outputs.artifact_name }}
           path: ${{ steps.artifact.outputs.artifact_path }}
-          if-no-files-found: error
-      - name: Prepare test support
-        if: ${{ !inputs.skip_tests && matrix.osx_build_arch == 'arm64' }}
-        id: test-support
-        run: python3 extension-ci-tools/scripts/ci_phase.py bundle_test_support
-      - name: Upload test support
-        if: ${{ !inputs.skip_tests && matrix.osx_build_arch == 'arm64' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ matrix.artifact_name }}-test-support
-          path: ${{ steps.test-support.outputs.test_support_path }}
-          retention-days: 1
           if-no-files-found: error
 
   build_windows:
@@ -397,18 +373,6 @@ jobs:
           name: ${{ steps.artifact.outputs.artifact_name }}
           path: ${{ steps.artifact.outputs.artifact_path }}
           if-no-files-found: error
-      - name: Prepare test support
-        if: ${{ !inputs.skip_tests }}
-        id: test-support
-        run: python extension-ci-tools/scripts/ci_phase.py bundle_test_support
-      - name: Upload test support
-        if: ${{ !inputs.skip_tests }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ matrix.artifact_name }}-test-support
-          path: ${{ steps.test-support.outputs.test_support_path }}
-          retention-days: 1
-          if-no-files-found: error
 
   build_wasm:
     name: Build Wasm (${{ matrix.artifact_prefix }}, ${{ matrix.duckdb_arch }})
@@ -503,7 +467,6 @@ jobs:
       CI_EXTENSION_NAME: all-extensions
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
-      CI_TEST_SUPPORT_DIR: ${{ github.workspace }}/.ci/test-support
       CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
     steps:
       - name: Checkout extension
@@ -527,15 +490,9 @@ jobs:
           pattern: ${{ matrix.artifact_pattern }}
           path: ${{ github.workspace }}/.ci/repository
           merge-multiple: true
-      - name: Download test support
-        if: ${{ !inputs.skip_tests && matrix.duckdb_arch != 'linux_arm64' }}
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          pattern: ${{ matrix.artifact_pattern }}-test-support
-          path: ${{ github.workspace }}/.ci/test-support
       - name: Test each group
         if: ${{ !inputs.skip_tests && matrix.duckdb_arch != 'linux_arm64' }}
-        run: python3 extension-ci-tools/scripts/ci_phase.py test_supports
+        run: python3 extension-ci-tools/scripts/ci_phase.py test
       - name: Deploy extensions
         if: ${{ inputs.deploy }}
         shell: bash
@@ -579,7 +536,6 @@ jobs:
       CI_EXTENSION_NAME: all-extensions
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
-      CI_TEST_SUPPORT_DIR: ${{ github.workspace }}/.ci/test-support
       CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
     steps:
       - name: Checkout extension
@@ -607,15 +563,9 @@ jobs:
           pattern: ${{ matrix.artifact_pattern }}
           path: ${{ github.workspace }}/.ci/repository
           merge-multiple: true
-      - name: Download test support
-        if: ${{ !inputs.skip_tests && matrix.osx_build_arch == 'arm64' }}
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          pattern: ${{ matrix.artifact_pattern }}-test-support
-          path: ${{ github.workspace }}/.ci/test-support
       - name: Test each group
         if: ${{ !inputs.skip_tests && matrix.osx_build_arch == 'arm64' }}
-        run: python3 extension-ci-tools/scripts/ci_phase.py test_supports
+        run: python3 extension-ci-tools/scripts/ci_phase.py test
       - name: Deploy extensions
         if: ${{ inputs.deploy }}
         shell: bash
@@ -650,7 +600,6 @@ jobs:
       CI_EXTENSION_NAME: all-extensions
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
-      CI_TEST_SUPPORT_DIR: ${{ github.workspace }}/.ci/test-support
       CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
     steps:
       - name: Configure line endings
@@ -683,15 +632,9 @@ jobs:
           pattern: ${{ matrix.artifact_pattern }}
           path: ${{ github.workspace }}/.ci/repository
           merge-multiple: true
-      - name: Download test support
-        if: ${{ !inputs.skip_tests }}
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          pattern: ${{ matrix.artifact_pattern }}-test-support
-          path: ${{ github.workspace }}/.ci/test-support
       - name: Test each group
         if: ${{ !inputs.skip_tests }}
-        run: python extension-ci-tools/scripts/ci_phase.py test_supports
+        run: python extension-ci-tools/scripts/ci_phase.py test
       - name: Deploy extensions
         if: ${{ inputs.deploy }}
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,6 +389,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.matrix.outputs.build_wasm) }}
     env:
+      GEN: make
       CI_PLATFORM: wasm
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
       WASM_EXTENSIONS: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,775 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      duckdb_version:
+        description: DuckDB ref to build against
+        required: true
+        type: string
+      ci_tools_version:
+        description: extension-ci-tools ref used by build and test jobs
+        required: true
+        type: string
+      groups:
+        description: YAML extension groups passed to duckdb-ci/matrix
+        required: true
+        type: string
+      extension_repository:
+        description: Extension repository override
+        required: false
+        type: string
+        default: ""
+      extension_ref:
+        description: Extension repository ref override
+        required: false
+        type: string
+        default: ""
+      duckdb_repository:
+        description: DuckDB repository override used by the extension Makefile
+        required: false
+        type: string
+        default: ""
+      ci_tools_repository:
+        description: Repository containing extension-ci-tools
+        required: false
+        type: string
+        default: duckdb/extension-ci-tools
+      exclude_archs:
+        description: Semicolon-separated architectures to exclude
+        required: false
+        type: string
+        default: ""
+      opt_in_archs:
+        description: Semicolon-separated opt-in architectures
+        required: false
+        type: string
+        default: ""
+      runners:
+        description: JSON runner overrides accepted by duckdb-ci/matrix
+        required: false
+        type: string
+        default: "{}"
+      reduced_ci_mode:
+        description: Reduced CI mode (auto, enabled, or disabled)
+        required: false
+        type: string
+        default: auto
+      image_version:
+        description: duckdb-ci container image version
+        required: false
+        type: string
+        default: 20260814-e87a46ea
+      skip_tests:
+        description: Skip tests while retaining artifact consumption and deployment
+        required: false
+        type: boolean
+        default: false
+      deploy:
+        description: Deploy all unique extension binaries from each architecture
+        required: false
+        type: boolean
+        default: false
+      vcpkg_url:
+        description: vcpkg repository
+        required: false
+        type: string
+        default: https://github.com/microsoft/vcpkg.git
+      vcpkg_commit:
+        description: vcpkg commit
+        required: false
+        type: string
+        default: 84bab45d415d22042bd0b9081aea57f362da3f35
+    secrets:
+      VCPKG_CACHING_AWS_ACCESS_KEY_ID:
+        required: false
+      VCPKG_CACHING_AWS_SECRET_ACCESS_KEY:
+        required: false
+      VCPKG_CACHING_AWS_ENDPOINT_URL:
+        required: false
+      VCPKG_CACHING_AWS_DEFAULT_REGION:
+        required: false
+      DUCKDB_EXTENSIONS_NIGHTLY_S3_ENDPOINT:
+        required: false
+      DUCKDB_EXTENSIONS_NIGHTLY_S3_ID:
+        required: false
+      DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY:
+        required: false
+      S3_DUCKDB_ORG_EXTENSION_SIGNING_PK:
+        required: false
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  CI_DUCKDB_VERSION: ${{ inputs.duckdb_version }}
+  CI_DUCKDB_GIT_REPOSITORY: ${{ inputs.duckdb_repository }}
+  CI_BUILD_TYPE: release
+  CI_BUILD_DUCKDB_SHELL: true
+  CI_UPLOAD_ALL_EXTENSIONS: true
+  CI_SKIP_TESTS: ${{ inputs.skip_tests }}
+  CI_EXTENSIONS_TEST_SELECTION: complete
+  CI_VCPKG_URL: ${{ inputs.vcpkg_url }}
+  CI_VCPKG_COMMIT: ${{ inputs.vcpkg_commit }}
+  CI_VCPKG_OVERLAY_PORTS: extension-ci-tools/vcpkg_ports
+  CI_VCPKG_OVERLAY_TRIPLETS: extension-ci-tools/toolchains
+  CI_CUDA_VERSION: 13
+  VCPKG_BINARY_SOURCES: clear;http,https://vcpkg-cache.duckdb.org,read
+  AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+  GEN: ninja
+
+jobs:
+  matrix:
+    name: Compute matrix
+    runs-on: ubuntu-slim
+    outputs:
+      build_linux: ${{ steps.matrix.outputs.build_linux }}
+      test_linux: ${{ steps.matrix.outputs.test_linux }}
+      build_macos: ${{ steps.matrix.outputs.build_macos }}
+      test_macos: ${{ steps.matrix.outputs.test_macos }}
+      build_windows: ${{ steps.matrix.outputs.build_windows }}
+      test_windows: ${{ steps.matrix.outputs.test_windows }}
+      build_wasm: ${{ steps.matrix.outputs.build_wasm }}
+      test_wasm: ${{ steps.matrix.outputs.test_wasm }}
+    steps:
+      - name: Compute matrix
+        id: matrix
+        uses: duckdb/duckdb-ci/matrix@main
+        with:
+          exclude_archs: ${{ inputs.exclude_archs }}
+          opt_in_archs: ${{ inputs.opt_in_archs }}
+          runners: ${{ inputs.runners }}
+          reduced_ci_mode: ${{ inputs.reduced_ci_mode }}
+          image_version: ${{ inputs.image_version }}
+          groups: ${{ inputs.groups }}
+
+  build_linux:
+    name: Build Linux (${{ matrix.artifact_prefix }}, ${{ matrix.duckdb_arch }})
+    needs: matrix
+    if: ${{ needs.matrix.outputs.build_linux != '' && needs.matrix.outputs.build_linux != '{"include":[]}' }}
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.container }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.build_linux) }}
+    env:
+      CI_PLATFORM: linux
+      CI_LINUX_NATIVE_CONTAINER: true
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      CI_EXTENSION_NAME: ${{ matrix.artifact_prefix }}
+      CI_ARTIFACT_NAME: ${{ matrix.artifact_name }}
+      CI_EXTENSION_CONFIG_PATHS: ${{ toJSON(matrix.extension_config_paths) }}
+      CI_EXTRA_TOOLCHAINS: ${{ matrix.toolchain }}
+      CI_HAS_RUST: ${{ matrix.toolchain == 'rust' }}
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
+      VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
+      AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
+      AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
+    steps:
+      - name: Checkout extension
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          ref: ${{ inputs.extension_ref }}
+          fetch-depth: 0
+          submodules: recursive
+      - name: Checkout extension-ci-tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: extension-ci-tools
+          repository: ${{ inputs.ci_tools_repository }}
+          ref: ${{ inputs.ci_tools_version }}
+      - name: Prepare sources
+        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+        continue-on-error: true
+        with:
+          max-size: 5GB
+          evict-old-files: job
+          key: build-${{ matrix.artifact_name }}-${{ inputs.duckdb_version }}
+      - name: Configure
+        run: python3 extension-ci-tools/scripts/ci_phase.py setup
+      - name: Build
+        run: python3 extension-ci-tools/scripts/ci_phase.py build
+      - name: Prepare extension artifact
+        id: artifact
+        run: python3 extension-ci-tools/scripts/ci_phase.py upload
+      - name: Upload extension artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.artifact.outputs.artifact_name }}
+          path: ${{ steps.artifact.outputs.artifact_path }}
+          if-no-files-found: error
+      - name: Prepare test support
+        if: ${{ !inputs.skip_tests && matrix.duckdb_arch != 'linux_arm64' }}
+        id: test-support
+        run: python3 extension-ci-tools/scripts/ci_phase.py bundle_test_support
+      - name: Upload test support
+        if: ${{ !inputs.skip_tests && matrix.duckdb_arch != 'linux_arm64' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.artifact_name }}-test-support
+          path: ${{ steps.test-support.outputs.test_support_path }}
+          retention-days: 1
+          if-no-files-found: error
+
+  build_macos:
+    name: Build macOS (${{ matrix.artifact_prefix }}, ${{ matrix.duckdb_arch }})
+    needs: matrix
+    if: ${{ needs.matrix.outputs.build_macos != '' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.build_macos) }}
+    env:
+      CI_PLATFORM: macos
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      CI_OSX_BUILD_ARCH: ${{ matrix.osx_build_arch }}
+      OSX_BUILD_ARCH: ${{ matrix.osx_build_arch }}
+      CI_EXTENSION_NAME: ${{ matrix.artifact_prefix }}
+      CI_ARTIFACT_NAME: ${{ matrix.artifact_name }}
+      CI_EXTENSION_CONFIG_PATHS: ${{ toJSON(matrix.extension_config_paths) }}
+      CI_EXTRA_TOOLCHAINS: ${{ matrix.toolchain }}
+      CI_HAS_RUST: ${{ matrix.toolchain == 'rust' }}
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
+      VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
+      AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
+      AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
+    steps:
+      - name: Checkout extension
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          ref: ${{ inputs.extension_ref }}
+          fetch-depth: 0
+          submodules: recursive
+      - name: Checkout extension-ci-tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: extension-ci-tools
+          repository: ${{ inputs.ci_tools_repository }}
+          ref: ${{ inputs.ci_tools_version }}
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+      - name: Setup Rust
+        if: ${{ matrix.toolchain == 'rust' }}
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - name: Prepare sources
+        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+        continue-on-error: true
+        with:
+          max-size: 5GB
+          evict-old-files: job
+          key: build-${{ matrix.artifact_name }}-${{ inputs.duckdb_version }}
+      - name: Configure
+        run: python3 extension-ci-tools/scripts/ci_phase.py setup
+      - name: Build
+        run: python3 extension-ci-tools/scripts/ci_phase.py build
+      - name: Prepare extension artifact
+        id: artifact
+        run: python3 extension-ci-tools/scripts/ci_phase.py upload
+      - name: Upload extension artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.artifact.outputs.artifact_name }}
+          path: ${{ steps.artifact.outputs.artifact_path }}
+          if-no-files-found: error
+      - name: Prepare test support
+        if: ${{ !inputs.skip_tests && matrix.osx_build_arch == 'arm64' }}
+        id: test-support
+        run: python3 extension-ci-tools/scripts/ci_phase.py bundle_test_support
+      - name: Upload test support
+        if: ${{ !inputs.skip_tests && matrix.osx_build_arch == 'arm64' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.artifact_name }}-test-support
+          path: ${{ steps.test-support.outputs.test_support_path }}
+          retention-days: 1
+          if-no-files-found: error
+
+  build_windows:
+    name: Build Windows (${{ matrix.artifact_prefix }}, ${{ matrix.duckdb_arch }})
+    needs: matrix
+    if: ${{ needs.matrix.outputs.build_windows != '' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.build_windows) }}
+    env:
+      CI_PLATFORM: windows
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      CI_EXTENSION_NAME: ${{ matrix.artifact_prefix }}
+      CI_ARTIFACT_NAME: ${{ matrix.artifact_name }}
+      CI_EXTENSION_CONFIG_PATHS: ${{ toJSON(matrix.extension_config_paths) }}
+      CI_EXTRA_TOOLCHAINS: ${{ matrix.toolchain }}
+      CI_HAS_RUST: ${{ matrix.toolchain == 'rust' }}
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
+      VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
+      AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
+      AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
+      CC: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 'gcc' || 'cl' }}
+      CXX: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 'g++' || 'cl' }}
+    steps:
+      - name: Configure line endings
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+      - name: Checkout extension
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          ref: ${{ inputs.extension_ref }}
+          fetch-depth: 0
+          submodules: recursive
+      - name: Checkout extension-ci-tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: extension-ci-tools
+          repository: ${{ inputs.ci_tools_repository }}
+          ref: ${{ inputs.ci_tools_version }}
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+      - name: Setup Rust
+        if: ${{ matrix.toolchain == 'rust' }}
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - name: Setup Rust for MinGW
+        if: ${{ matrix.toolchain == 'rust' && (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') }}
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          targets: x86_64-pc-windows-gnu
+      - name: Setup Rtools
+        if: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw' }}
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+        with:
+          r-version: devel
+          update-rtools: true
+          rtools-version: "42"
+      - name: Prepare sources
+        run: python extension-ci-tools/scripts/ci_phase.py checkout
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+        with:
+          max-size: 5GB
+          evict-old-files: job
+          key: build-${{ matrix.artifact_name }}-${{ inputs.duckdb_version }}
+      - name: Configure short vcpkg path
+        shell: pwsh
+        run: |
+          $basePath = Split-Path -Path (Split-Path -Path $env:GITHUB_WORKSPACE -Parent) -Parent
+          $vcpkgRoot = "$basePath/vcpkg"
+          "VCPKG_WINDOWS_ROOT=$vcpkgRoot" >> $env:GITHUB_ENV
+          "VCPKG_TOOLCHAIN_PATH=$vcpkgRoot/scripts/buildsystems/vcpkg.cmake" >> $env:GITHUB_ENV
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
+        with:
+          vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
+          vcpkgGitURL: ${{ inputs.vcpkg_url }}
+          vcpkgDirectory: ${{ env.VCPKG_WINDOWS_ROOT }}
+      - name: Configure
+        run: python extension-ci-tools/scripts/ci_phase.py setup
+      - name: Build
+        run: python extension-ci-tools/scripts/ci_phase.py build
+      - name: Prepare extension artifact
+        id: artifact
+        run: python extension-ci-tools/scripts/ci_phase.py upload
+      - name: Upload extension artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.artifact.outputs.artifact_name }}
+          path: ${{ steps.artifact.outputs.artifact_path }}
+          if-no-files-found: error
+      - name: Prepare test support
+        if: ${{ !inputs.skip_tests }}
+        id: test-support
+        run: python extension-ci-tools/scripts/ci_phase.py bundle_test_support
+      - name: Upload test support
+        if: ${{ !inputs.skip_tests }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.artifact_name }}-test-support
+          path: ${{ steps.test-support.outputs.test_support_path }}
+          retention-days: 1
+          if-no-files-found: error
+
+  build_wasm:
+    name: Build Wasm (${{ matrix.artifact_prefix }}, ${{ matrix.duckdb_arch }})
+    needs: matrix
+    if: ${{ needs.matrix.outputs.build_wasm != '' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.build_wasm) }}
+    env:
+      CI_PLATFORM: wasm
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      WASM_EXTENSIONS: 1
+      CI_EXTENSION_NAME: ${{ matrix.artifact_prefix }}
+      CI_ARTIFACT_NAME: ${{ matrix.artifact_name }}
+      CI_EXTENSION_CONFIG_PATHS: ${{ toJSON(matrix.extension_config_paths) }}
+      CI_EXTRA_TOOLCHAINS: ${{ matrix.toolchain }}
+      CI_HAS_RUST: ${{ matrix.toolchain == 'rust' }}
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
+      VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
+      AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
+      AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
+    steps:
+      - name: Checkout extension
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          ref: ${{ inputs.extension_ref }}
+          fetch-depth: 0
+          submodules: recursive
+      - name: Checkout extension-ci-tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: extension-ci-tools
+          repository: ${{ inputs.ci_tools_repository }}
+          ref: ${{ inputs.ci_tools_version }}
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+      - name: Setup Emscripten
+        uses: emscripten-core/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
+        with:
+          version: 3.1.71
+      - name: Setup Rust
+        if: ${{ matrix.toolchain == 'rust' }}
+        uses: dtolnay/rust-toolchain@4d407b29186a635f0cc27475ef0bc0ae605a8866 # 1.86.0
+        with:
+          targets: wasm32-unknown-emscripten
+      - name: Prepare sources
+        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+        continue-on-error: true
+        with:
+          max-size: 5GB
+          evict-old-files: job
+          key: build-${{ matrix.artifact_name }}-${{ inputs.duckdb_version }}
+      - name: Configure
+        run: python3 extension-ci-tools/scripts/ci_phase.py setup
+      - name: Build
+        run: python3 extension-ci-tools/scripts/ci_phase.py build
+      - name: Prepare extension artifact
+        id: artifact
+        run: python3 extension-ci-tools/scripts/ci_phase.py upload
+      - name: Upload extension artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.artifact.outputs.artifact_name }}
+          path: ${{ steps.artifact.outputs.artifact_path }}
+          if-no-files-found: error
+
+  test_linux:
+    name: Test/deploy Linux (${{ matrix.duckdb_arch }})
+    needs: [matrix, build_linux]
+    if: ${{ !cancelled() && needs.matrix.outputs.test_linux != '' && needs.matrix.outputs.test_linux != '{"include":[]}' && needs.build_linux.result == 'success' }}
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.container }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.test_linux) }}
+    env:
+      CI_PLATFORM: linux
+      CI_LINUX_NATIVE_CONTAINER: true
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      CI_EXTENSION_NAME: all-extensions
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
+      VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
+      CI_TEST_SUPPORT_DIR: ${{ github.workspace }}/.ci/test-support
+      CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
+    steps:
+      - name: Checkout extension
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          ref: ${{ inputs.extension_ref }}
+          fetch-depth: 0
+          submodules: recursive
+      - name: Checkout extension-ci-tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: extension-ci-tools
+          repository: ${{ inputs.ci_tools_repository }}
+          ref: ${{ inputs.ci_tools_version }}
+      - name: Prepare sources
+        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
+      - name: Download extension artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: ${{ matrix.artifact_pattern }}
+          path: ${{ github.workspace }}/.ci/repository
+          merge-multiple: true
+      - name: Download test support
+        if: ${{ !inputs.skip_tests && matrix.duckdb_arch != 'linux_arm64' }}
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: ${{ matrix.artifact_pattern }}-test-support
+          path: ${{ github.workspace }}/.ci/test-support
+      - name: Test each group
+        if: ${{ !inputs.skip_tests && matrix.duckdb_arch != 'linux_arm64' }}
+        run: python3 extension-ci-tools/scripts/ci_phase.py test_supports
+      - name: Deploy extensions
+        if: ${{ inputs.deploy }}
+        shell: bash
+        env:
+          AWS_ENDPOINT_URL: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY }}
+          DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.S3_DUCKDB_ORG_EXTENSION_SIGNING_PK }}
+          DUCKDB_DEPLOY_SCRIPT_MODE: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY != '' && 'for_real' || '' }}
+          PIP_BREAK_SYSTEM_PACKAGES: 1
+        run: |
+          python3 -m pip install awscli
+          git config --global --add safe.directory '*'
+          git fetch --tags
+          git -C duckdb fetch --tags
+          extension_version="$(git tag --points-at HEAD | head -n 1)"
+          extension_version="${extension_version:-$(git rev-parse --short HEAD)}"
+          duckdb_version="$(git -C duckdb tag --points-at HEAD | head -n 1)"
+          duckdb_version="${duckdb_version:-$(git -C duckdb rev-parse --short HEAD)}"
+          python3 extension-ci-tools/scripts/deploy_artifacts.py \
+            --root "$CI_EXTENSION_ARTIFACT_DIR" \
+            --script ./duckdb/scripts/extension-upload-single.sh \
+            --extension-version "$extension_version" \
+            --duckdb-version "$duckdb_version" \
+            --architecture "${{ matrix.duckdb_arch }}" \
+            --bucket duckdb-extensions-nightly
+
+  test_macos:
+    name: Test/deploy macOS (${{ matrix.duckdb_arch }})
+    needs: [matrix, build_macos]
+    if: ${{ !cancelled() && needs.matrix.outputs.test_macos != '' && needs.matrix.outputs.test_macos != '{"include":[]}' && needs.build_macos.result == 'success' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.test_macos) }}
+    env:
+      CI_PLATFORM: macos
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      CI_OSX_BUILD_ARCH: ${{ matrix.osx_build_arch }}
+      OSX_BUILD_ARCH: ${{ matrix.osx_build_arch }}
+      CI_EXTENSION_NAME: all-extensions
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
+      VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
+      CI_TEST_SUPPORT_DIR: ${{ github.workspace }}/.ci/test-support
+      CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
+    steps:
+      - name: Checkout extension
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          ref: ${{ inputs.extension_ref }}
+          fetch-depth: 0
+          submodules: recursive
+      - name: Checkout extension-ci-tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: extension-ci-tools
+          repository: ${{ inputs.ci_tools_repository }}
+          ref: ${{ inputs.ci_tools_version }}
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+      - name: Prepare sources
+        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
+      - name: Download extension artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: ${{ matrix.artifact_pattern }}
+          path: ${{ github.workspace }}/.ci/repository
+          merge-multiple: true
+      - name: Download test support
+        if: ${{ !inputs.skip_tests && matrix.osx_build_arch == 'arm64' }}
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: ${{ matrix.artifact_pattern }}-test-support
+          path: ${{ github.workspace }}/.ci/test-support
+      - name: Test each group
+        if: ${{ !inputs.skip_tests && matrix.osx_build_arch == 'arm64' }}
+        run: python3 extension-ci-tools/scripts/ci_phase.py test_supports
+      - name: Deploy extensions
+        if: ${{ inputs.deploy }}
+        shell: bash
+        env:
+          AWS_ENDPOINT_URL: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY }}
+          DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.S3_DUCKDB_ORG_EXTENSION_SIGNING_PK }}
+          DUCKDB_DEPLOY_SCRIPT_MODE: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY != '' && 'for_real' || '' }}
+          PIP_BREAK_SYSTEM_PACKAGES: 1
+        run: |
+          python3 -m pip install awscli
+          git fetch --tags
+          git -C duckdb fetch --tags
+          extension_version="$(git tag --points-at HEAD | head -n 1)"
+          extension_version="${extension_version:-$(git rev-parse --short HEAD)}"
+          duckdb_version="$(git -C duckdb tag --points-at HEAD | head -n 1)"
+          duckdb_version="${duckdb_version:-$(git -C duckdb rev-parse --short HEAD)}"
+          python3 extension-ci-tools/scripts/deploy_artifacts.py --root "$CI_EXTENSION_ARTIFACT_DIR" --script ./duckdb/scripts/extension-upload-single.sh --extension-version "$extension_version" --duckdb-version "$duckdb_version" --architecture "${{ matrix.duckdb_arch }}" --bucket duckdb-extensions-nightly
+
+  test_windows:
+    name: Test/deploy Windows (${{ matrix.duckdb_arch }})
+    needs: [matrix, build_windows]
+    if: ${{ !cancelled() && needs.matrix.outputs.test_windows != '' && needs.matrix.outputs.test_windows != '{"include":[]}' && needs.build_windows.result == 'success' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.test_windows) }}
+    env:
+      CI_PLATFORM: windows
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      CI_EXTENSION_NAME: all-extensions
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
+      VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
+      CI_TEST_SUPPORT_DIR: ${{ github.workspace }}/.ci/test-support
+      CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
+    steps:
+      - name: Configure line endings
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+      - name: Checkout extension
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          ref: ${{ inputs.extension_ref }}
+          fetch-depth: 0
+          submodules: recursive
+      - name: Checkout extension-ci-tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: extension-ci-tools
+          repository: ${{ inputs.ci_tools_repository }}
+          ref: ${{ inputs.ci_tools_version }}
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+      - name: Prepare sources
+        run: python extension-ci-tools/scripts/ci_phase.py checkout
+      - name: Download extension artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: ${{ matrix.artifact_pattern }}
+          path: ${{ github.workspace }}/.ci/repository
+          merge-multiple: true
+      - name: Download test support
+        if: ${{ !inputs.skip_tests }}
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: ${{ matrix.artifact_pattern }}-test-support
+          path: ${{ github.workspace }}/.ci/test-support
+      - name: Test each group
+        if: ${{ !inputs.skip_tests }}
+        run: python extension-ci-tools/scripts/ci_phase.py test_supports
+      - name: Deploy extensions
+        if: ${{ inputs.deploy }}
+        shell: bash
+        env:
+          AWS_ENDPOINT_URL: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY }}
+          DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.S3_DUCKDB_ORG_EXTENSION_SIGNING_PK }}
+          DUCKDB_DEPLOY_SCRIPT_MODE: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY != '' && 'for_real' || '' }}
+          PIP_BREAK_SYSTEM_PACKAGES: 1
+        run: |
+          python -m pip install awscli
+          git fetch --tags
+          git -C duckdb fetch --tags
+          extension_version="$(git tag --points-at HEAD | head -n 1)"
+          extension_version="${extension_version:-$(git rev-parse --short HEAD)}"
+          duckdb_version="$(git -C duckdb tag --points-at HEAD | head -n 1)"
+          duckdb_version="${duckdb_version:-$(git -C duckdb rev-parse --short HEAD)}"
+          python extension-ci-tools/scripts/deploy_artifacts.py --root "$CI_EXTENSION_ARTIFACT_DIR" --script ./duckdb/scripts/extension-upload-single.sh --extension-version "$extension_version" --duckdb-version "$duckdb_version" --architecture "${{ matrix.duckdb_arch }}" --bucket duckdb-extensions-nightly
+
+  test_wasm:
+    name: Deploy Wasm (${{ matrix.duckdb_arch }})
+    needs: [matrix, build_wasm]
+    if: ${{ !cancelled() && needs.matrix.outputs.test_wasm != '' && needs.matrix.outputs.test_wasm != '{"include":[]}' && needs.build_wasm.result == 'success' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.test_wasm) }}
+    env:
+      CI_PLATFORM: wasm
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      CI_EXTENSION_NAME: all-extensions
+      CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
+    steps:
+      - name: Checkout extension
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          ref: ${{ inputs.extension_ref }}
+          fetch-depth: 0
+          submodules: recursive
+      - name: Checkout extension-ci-tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: extension-ci-tools
+          repository: ${{ inputs.ci_tools_repository }}
+          ref: ${{ inputs.ci_tools_version }}
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+      - name: Prepare sources
+        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
+      - name: Download extension artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: ${{ matrix.artifact_pattern }}
+          path: ${{ github.workspace }}/.ci/repository
+          merge-multiple: true
+      - name: Skip Wasm tests
+        if: ${{ !inputs.skip_tests }}
+        run: python3 extension-ci-tools/scripts/ci_phase.py test
+      - name: Deploy extensions
+        if: ${{ inputs.deploy }}
+        shell: bash
+        env:
+          AWS_ENDPOINT_URL: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY }}
+          DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.S3_DUCKDB_ORG_EXTENSION_SIGNING_PK }}
+          DUCKDB_DEPLOY_SCRIPT_MODE: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY != '' && 'for_real' || '' }}
+          PIP_BREAK_SYSTEM_PACKAGES: 1
+        run: |
+          python3 -m pip install awscli
+          git fetch --tags
+          git -C duckdb fetch --tags
+          extension_version="$(git tag --points-at HEAD | head -n 1)"
+          extension_version="${extension_version:-$(git rev-parse --short HEAD)}"
+          duckdb_version="$(git -C duckdb tag --points-at HEAD | head -n 1)"
+          duckdb_version="${duckdb_version:-$(git -C duckdb rev-parse --short HEAD)}"
+          python3 extension-ci-tools/scripts/deploy_artifacts.py --root "$CI_EXTENSION_ARTIFACT_DIR" --script ./duckdb/scripts/extension-upload-single.sh --extension-version "$extension_version" --duckdb-version "$duckdb_version" --architecture "${{ matrix.duckdb_arch }}" --bucket duckdb-extensions-nightly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,6 @@ permissions:
 
 env:
   CI_DUCKDB_VERSION: ${{ inputs.duckdb_version }}
-  CI_DUCKDB_GIT_REPOSITORY: ${{ inputs.duckdb_repository }}
   CI_BUILD_TYPE: release
   CI_BUILD_DUCKDB_SHELL: true
   CI_UPLOAD_ALL_EXTENSIONS: true
@@ -164,21 +163,20 @@ jobs:
       AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
     steps:
-      - name: Checkout extension
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Prepare sources
+        uses: duckdb/duckdb-ci/prepare-extension@main
         with:
-          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
-          ref: ${{ inputs.extension_ref }}
-          fetch-depth: 0
-          submodules: recursive
+          extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          extension-ref: ${{ inputs.extension_ref }}
+          duckdb-repository: ${{ inputs.duckdb_repository != '' && inputs.duckdb_repository || 'duckdb/duckdb' }}
+          duckdb-ref: ${{ inputs.duckdb_version }}
+          duckdb-sha: ${{ inputs.duckdb_version }}
       - name: Checkout extension-ci-tools
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: extension-ci-tools
           repository: ${{ inputs.ci_tools_repository }}
           ref: ${{ inputs.ci_tools_version }}
-      - name: Prepare sources
-        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         continue-on-error: true
@@ -190,7 +188,12 @@ jobs:
       - name: Configure
         run: python3 extension-ci-tools/scripts/ci_phase.py setup
       - name: Build
-        run: python3 extension-ci-tools/scripts/ci_phase.py build
+        uses: duckdb/duckdb-ci/build-duckdb@main
+        with:
+          build: python3 extension-ci-tools/scripts/ci_phase.py build
+          vcpkg-commit: ${{ inputs.vcpkg_commit }}
+          save-cache: ${{ inputs.save_cache }}
+          cache-suffix: ${{ matrix.group_name }}-${{ matrix.container_name || matrix.duckdb_arch }}
       - name: Prepare extension artifact
         id: artifact
         run: python3 extension-ci-tools/scripts/ci_phase.py upload
@@ -226,13 +229,14 @@ jobs:
       AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
     steps:
-      - name: Checkout extension
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Prepare sources
+        uses: duckdb/duckdb-ci/prepare-extension@main
         with:
-          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
-          ref: ${{ inputs.extension_ref }}
-          fetch-depth: 0
-          submodules: recursive
+          extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          extension-ref: ${{ inputs.extension_ref }}
+          duckdb-repository: ${{ inputs.duckdb_repository != '' && inputs.duckdb_repository || 'duckdb/duckdb' }}
+          duckdb-ref: ${{ inputs.duckdb_version }}
+          duckdb-sha: ${{ inputs.duckdb_version }}
       - name: Checkout extension-ci-tools
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -246,8 +250,6 @@ jobs:
       - name: Setup Rust
         if: ${{ matrix.toolchain == 'rust' }}
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      - name: Prepare sources
-        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         continue-on-error: true
@@ -259,7 +261,12 @@ jobs:
       - name: Configure
         run: python3 extension-ci-tools/scripts/ci_phase.py setup
       - name: Build
-        run: python3 extension-ci-tools/scripts/ci_phase.py build
+        uses: duckdb/duckdb-ci/build-duckdb@main
+        with:
+          build: python3 extension-ci-tools/scripts/ci_phase.py build
+          vcpkg-commit: ${{ inputs.vcpkg_commit }}
+          save-cache: ${{ inputs.save_cache }}
+          cache-suffix: ${{ matrix.group_name }}-${{ matrix.container_name || matrix.duckdb_arch }}
       - name: Prepare extension artifact
         id: artifact
         run: python3 extension-ci-tools/scripts/ci_phase.py upload
@@ -300,13 +307,14 @@ jobs:
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
-      - name: Checkout extension
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Prepare sources
+        uses: duckdb/duckdb-ci/prepare-extension@main
         with:
-          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
-          ref: ${{ inputs.extension_ref }}
-          fetch-depth: 0
-          submodules: recursive
+          extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          extension-ref: ${{ inputs.extension_ref }}
+          duckdb-repository: ${{ inputs.duckdb_repository != '' && inputs.duckdb_repository || 'duckdb/duckdb' }}
+          duckdb-ref: ${{ inputs.duckdb_version }}
+          duckdb-sha: ${{ inputs.duckdb_version }}
       - name: Checkout extension-ci-tools
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -332,8 +340,6 @@ jobs:
           r-version: devel
           update-rtools: true
           rtools-version: "42"
-      - name: Prepare sources
-        run: python extension-ci-tools/scripts/ci_phase.py checkout
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
@@ -347,6 +353,7 @@ jobs:
           $basePath = Split-Path -Path (Split-Path -Path $env:GITHUB_WORKSPACE -Parent) -Parent
           $vcpkgRoot = "$basePath/vcpkg"
           "VCPKG_WINDOWS_ROOT=$vcpkgRoot" >> $env:GITHUB_ENV
+          "VCPKG_ROOT=$vcpkgRoot" >> $env:GITHUB_ENV
           "VCPKG_TOOLCHAIN_PATH=$vcpkgRoot/scripts/buildsystems/vcpkg.cmake" >> $env:GITHUB_ENV
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
@@ -357,7 +364,12 @@ jobs:
       - name: Configure
         run: python extension-ci-tools/scripts/ci_phase.py setup
       - name: Build
-        run: python extension-ci-tools/scripts/ci_phase.py build
+        uses: duckdb/duckdb-ci/build-duckdb@main
+        with:
+          build: python extension-ci-tools/scripts/ci_phase.py build
+          vcpkg-commit: ${{ inputs.vcpkg_commit }}
+          save-cache: ${{ inputs.save_cache }}
+          cache-suffix: ${{ matrix.group_name }}-${{ matrix.container_name || matrix.duckdb_arch }}
       - name: Prepare extension artifact
         id: artifact
         run: python extension-ci-tools/scripts/ci_phase.py upload
@@ -392,13 +404,14 @@ jobs:
       AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
     steps:
-      - name: Checkout extension
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Prepare sources
+        uses: duckdb/duckdb-ci/prepare-extension@main
         with:
-          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
-          ref: ${{ inputs.extension_ref }}
-          fetch-depth: 0
-          submodules: recursive
+          extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          extension-ref: ${{ inputs.extension_ref }}
+          duckdb-repository: ${{ inputs.duckdb_repository != '' && inputs.duckdb_repository || 'duckdb/duckdb' }}
+          duckdb-ref: ${{ inputs.duckdb_version }}
+          duckdb-sha: ${{ inputs.duckdb_version }}
       - name: Checkout extension-ci-tools
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -418,8 +431,6 @@ jobs:
         uses: dtolnay/rust-toolchain@4d407b29186a635f0cc27475ef0bc0ae605a8866 # 1.86.0
         with:
           targets: wasm32-unknown-emscripten
-      - name: Prepare sources
-        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         continue-on-error: true
@@ -431,7 +442,12 @@ jobs:
       - name: Configure
         run: python3 extension-ci-tools/scripts/ci_phase.py setup
       - name: Build
-        run: python3 extension-ci-tools/scripts/ci_phase.py build
+        uses: duckdb/duckdb-ci/build-duckdb@main
+        with:
+          build: python3 extension-ci-tools/scripts/ci_phase.py build
+          vcpkg-commit: ${{ inputs.vcpkg_commit }}
+          save-cache: ${{ inputs.save_cache }}
+          cache-suffix: ${{ matrix.group_name }}-${{ matrix.container_name || matrix.duckdb_arch }}
       - name: Prepare extension artifact
         id: artifact
         run: python3 extension-ci-tools/scripts/ci_phase.py upload
@@ -464,21 +480,20 @@ jobs:
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
       CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
     steps:
-      - name: Checkout extension
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Prepare sources
+        uses: duckdb/duckdb-ci/prepare-extension@main
         with:
-          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
-          ref: ${{ inputs.extension_ref }}
-          fetch-depth: 0
-          submodules: recursive
+          extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          extension-ref: ${{ inputs.extension_ref }}
+          duckdb-repository: ${{ inputs.duckdb_repository != '' && inputs.duckdb_repository || 'duckdb/duckdb' }}
+          duckdb-ref: ${{ inputs.duckdb_version }}
+          duckdb-sha: ${{ inputs.duckdb_version }}
       - name: Checkout extension-ci-tools
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: extension-ci-tools
           repository: ${{ inputs.ci_tools_repository }}
           ref: ${{ inputs.ci_tools_version }}
-      - name: Prepare sources
-        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
       - name: Download extension artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -507,13 +522,14 @@ jobs:
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
       CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
     steps:
-      - name: Checkout extension
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Prepare sources
+        uses: duckdb/duckdb-ci/prepare-extension@main
         with:
-          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
-          ref: ${{ inputs.extension_ref }}
-          fetch-depth: 0
-          submodules: recursive
+          extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          extension-ref: ${{ inputs.extension_ref }}
+          duckdb-repository: ${{ inputs.duckdb_repository != '' && inputs.duckdb_repository || 'duckdb/duckdb' }}
+          duckdb-ref: ${{ inputs.duckdb_version }}
+          duckdb-sha: ${{ inputs.duckdb_version }}
       - name: Checkout extension-ci-tools
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -524,8 +540,6 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
-      - name: Prepare sources
-        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
       - name: Download extension artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -557,13 +571,14 @@ jobs:
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
-      - name: Checkout extension
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Prepare sources
+        uses: duckdb/duckdb-ci/prepare-extension@main
         with:
-          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
-          ref: ${{ inputs.extension_ref }}
-          fetch-depth: 0
-          submodules: recursive
+          extension-repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
+          extension-ref: ${{ inputs.extension_ref }}
+          duckdb-repository: ${{ inputs.duckdb_repository != '' && inputs.duckdb_repository || 'duckdb/duckdb' }}
+          duckdb-ref: ${{ inputs.duckdb_version }}
+          duckdb-sha: ${{ inputs.duckdb_version }}
       - name: Checkout extension-ci-tools
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -574,8 +589,6 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
-      - name: Prepare sources
-        run: python extension-ci-tools/scripts/ci_phase.py checkout
       - name: Download extension artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,7 @@ jobs:
         uses: duckdb/duckdb-ci/build-duckdb@main
         with:
           build: python3 extension-ci-tools/scripts/ci_phase.py build
+          test: python3 extension-ci-tools/scripts/ci_phase.py test
           vcpkg-commit: ${{ inputs.vcpkg_commit }}
           save-cache: ${{ inputs.save_cache }}
           cache-suffix: ${{ matrix.group_name }}-${{ matrix.container_name || matrix.duckdb_arch }}
@@ -264,6 +265,7 @@ jobs:
         uses: duckdb/duckdb-ci/build-duckdb@main
         with:
           build: python3 extension-ci-tools/scripts/ci_phase.py build
+          test: python3 extension-ci-tools/scripts/ci_phase.py test
           vcpkg-commit: ${{ inputs.vcpkg_commit }}
           save-cache: ${{ inputs.save_cache }}
           cache-suffix: ${{ matrix.group_name }}-${{ matrix.container_name || matrix.duckdb_arch }}
@@ -367,6 +369,7 @@ jobs:
         uses: duckdb/duckdb-ci/build-duckdb@main
         with:
           build: python extension-ci-tools/scripts/ci_phase.py build
+          test: python extension-ci-tools/scripts/ci_phase.py test
           vcpkg-commit: ${{ inputs.vcpkg_commit }}
           save-cache: ${{ inputs.save_cache }}
           cache-suffix: ${{ matrix.group_name }}-${{ matrix.container_name || matrix.duckdb_arch }}
@@ -446,6 +449,7 @@ jobs:
         uses: duckdb/duckdb-ci/build-duckdb@main
         with:
           build: python3 extension-ci-tools/scripts/ci_phase.py build
+          test: python3 extension-ci-tools/scripts/ci_phase.py test
           vcpkg-commit: ${{ inputs.vcpkg_commit }}
           save-cache: ${{ inputs.save_cache }}
           cache-suffix: ${{ matrix.group_name }}-${{ matrix.container_name || matrix.duckdb_arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,15 +61,15 @@ on:
         type: string
         default: 20260814-e87a46ea
       skip_tests:
-        description: Skip tests while retaining artifact consumption and deployment
+        description: Skip tests
         required: false
         type: boolean
         default: false
-      deploy:
-        description: Deploy all unique extension binaries from each architecture
+      save_cache:
+        description: Save ccache after the build
         required: false
         type: boolean
-        default: false
+        default: true
       vcpkg_url:
         description: vcpkg repository
         required: false
@@ -88,14 +88,6 @@ on:
       VCPKG_CACHING_AWS_ENDPOINT_URL:
         required: false
       VCPKG_CACHING_AWS_DEFAULT_REGION:
-        required: false
-      DUCKDB_EXTENSIONS_NIGHTLY_S3_ENDPOINT:
-        required: false
-      DUCKDB_EXTENSIONS_NIGHTLY_S3_ID:
-        required: false
-      DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY:
-        required: false
-      S3_DUCKDB_ORG_EXTENSION_SIGNING_PK:
         required: false
 
 permissions:
@@ -131,7 +123,6 @@ jobs:
       build_windows: ${{ steps.matrix.outputs.build_windows }}
       test_windows: ${{ steps.matrix.outputs.test_windows }}
       build_wasm: ${{ steps.matrix.outputs.build_wasm }}
-      test_wasm: ${{ steps.matrix.outputs.test_wasm }}
     steps:
       - name: Compute matrix
         id: matrix
@@ -195,6 +186,7 @@ jobs:
           max-size: 5GB
           evict-old-files: job
           key: build-${{ matrix.artifact_name }}-${{ inputs.duckdb_version }}
+          save: ${{ inputs.save_cache }}
       - name: Configure
         run: python3 extension-ci-tools/scripts/ci_phase.py setup
       - name: Build
@@ -263,6 +255,7 @@ jobs:
           max-size: 5GB
           evict-old-files: job
           key: build-${{ matrix.artifact_name }}-${{ inputs.duckdb_version }}
+          save: ${{ inputs.save_cache }}
       - name: Configure
         run: python3 extension-ci-tools/scripts/ci_phase.py setup
       - name: Build
@@ -347,6 +340,7 @@ jobs:
           max-size: 5GB
           evict-old-files: job
           key: build-${{ matrix.artifact_name }}-${{ inputs.duckdb_version }}
+          save: ${{ inputs.save_cache }}
       - name: Configure short vcpkg path
         shell: pwsh
         run: |
@@ -433,6 +427,7 @@ jobs:
           max-size: 5GB
           evict-old-files: job
           key: build-${{ matrix.artifact_name }}-${{ inputs.duckdb_version }}
+          save: ${{ inputs.save_cache }}
       - name: Configure
         run: python3 extension-ci-tools/scripts/ci_phase.py setup
       - name: Build
@@ -448,7 +443,7 @@ jobs:
           if-no-files-found: error
 
   test_linux:
-    name: Test/deploy Linux (${{ matrix.duckdb_arch }})
+    name: Test Linux (${{ matrix.duckdb_arch }})
     needs: [matrix, build_linux]
     if: ${{ !cancelled() && needs.matrix.outputs.test_linux != '' && needs.matrix.outputs.test_linux != '{"include":[]}' && needs.build_linux.result == 'success' }}
     runs-on: ${{ matrix.runner }}
@@ -493,35 +488,9 @@ jobs:
       - name: Test each group
         if: ${{ !inputs.skip_tests && matrix.duckdb_arch != 'linux_arm64' }}
         run: python3 extension-ci-tools/scripts/ci_phase.py test
-      - name: Deploy extensions
-        if: ${{ inputs.deploy }}
-        shell: bash
-        env:
-          AWS_ENDPOINT_URL: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY }}
-          DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.S3_DUCKDB_ORG_EXTENSION_SIGNING_PK }}
-          DUCKDB_DEPLOY_SCRIPT_MODE: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY != '' && 'for_real' || '' }}
-          PIP_BREAK_SYSTEM_PACKAGES: 1
-        run: |
-          python3 -m pip install awscli
-          git config --global --add safe.directory '*'
-          git fetch --tags
-          git -C duckdb fetch --tags
-          extension_version="$(git tag --points-at HEAD | head -n 1)"
-          extension_version="${extension_version:-$(git rev-parse --short HEAD)}"
-          duckdb_version="$(git -C duckdb tag --points-at HEAD | head -n 1)"
-          duckdb_version="${duckdb_version:-$(git -C duckdb rev-parse --short HEAD)}"
-          python3 extension-ci-tools/scripts/deploy_artifacts.py \
-            --root "$CI_EXTENSION_ARTIFACT_DIR" \
-            --script ./duckdb/scripts/extension-upload-single.sh \
-            --extension-version "$extension_version" \
-            --duckdb-version "$duckdb_version" \
-            --architecture "${{ matrix.duckdb_arch }}" \
-            --bucket duckdb-extensions-nightly
 
   test_macos:
-    name: Test/deploy macOS (${{ matrix.duckdb_arch }})
+    name: Test macOS (${{ matrix.duckdb_arch }})
     needs: [matrix, build_macos]
     if: ${{ !cancelled() && needs.matrix.outputs.test_macos != '' && needs.matrix.outputs.test_macos != '{"include":[]}' && needs.build_macos.result == 'success' }}
     runs-on: ${{ matrix.runner }}
@@ -566,28 +535,9 @@ jobs:
       - name: Test each group
         if: ${{ !inputs.skip_tests && matrix.osx_build_arch == 'arm64' }}
         run: python3 extension-ci-tools/scripts/ci_phase.py test
-      - name: Deploy extensions
-        if: ${{ inputs.deploy }}
-        shell: bash
-        env:
-          AWS_ENDPOINT_URL: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY }}
-          DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.S3_DUCKDB_ORG_EXTENSION_SIGNING_PK }}
-          DUCKDB_DEPLOY_SCRIPT_MODE: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY != '' && 'for_real' || '' }}
-          PIP_BREAK_SYSTEM_PACKAGES: 1
-        run: |
-          python3 -m pip install awscli
-          git fetch --tags
-          git -C duckdb fetch --tags
-          extension_version="$(git tag --points-at HEAD | head -n 1)"
-          extension_version="${extension_version:-$(git rev-parse --short HEAD)}"
-          duckdb_version="$(git -C duckdb tag --points-at HEAD | head -n 1)"
-          duckdb_version="${duckdb_version:-$(git -C duckdb rev-parse --short HEAD)}"
-          python3 extension-ci-tools/scripts/deploy_artifacts.py --root "$CI_EXTENSION_ARTIFACT_DIR" --script ./duckdb/scripts/extension-upload-single.sh --extension-version "$extension_version" --duckdb-version "$duckdb_version" --architecture "${{ matrix.duckdb_arch }}" --bucket duckdb-extensions-nightly
 
   test_windows:
-    name: Test/deploy Windows (${{ matrix.duckdb_arch }})
+    name: Test Windows (${{ matrix.duckdb_arch }})
     needs: [matrix, build_windows]
     if: ${{ !cancelled() && needs.matrix.outputs.test_windows != '' && needs.matrix.outputs.test_windows != '{"include":[]}' && needs.build_windows.result == 'success' }}
     runs-on: ${{ matrix.runner }}
@@ -635,84 +585,3 @@ jobs:
       - name: Test each group
         if: ${{ !inputs.skip_tests }}
         run: python extension-ci-tools/scripts/ci_phase.py test
-      - name: Deploy extensions
-        if: ${{ inputs.deploy }}
-        shell: bash
-        env:
-          AWS_ENDPOINT_URL: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY }}
-          DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.S3_DUCKDB_ORG_EXTENSION_SIGNING_PK }}
-          DUCKDB_DEPLOY_SCRIPT_MODE: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY != '' && 'for_real' || '' }}
-          PIP_BREAK_SYSTEM_PACKAGES: 1
-        run: |
-          python -m pip install awscli
-          git fetch --tags
-          git -C duckdb fetch --tags
-          extension_version="$(git tag --points-at HEAD | head -n 1)"
-          extension_version="${extension_version:-$(git rev-parse --short HEAD)}"
-          duckdb_version="$(git -C duckdb tag --points-at HEAD | head -n 1)"
-          duckdb_version="${duckdb_version:-$(git -C duckdb rev-parse --short HEAD)}"
-          python extension-ci-tools/scripts/deploy_artifacts.py --root "$CI_EXTENSION_ARTIFACT_DIR" --script ./duckdb/scripts/extension-upload-single.sh --extension-version "$extension_version" --duckdb-version "$duckdb_version" --architecture "${{ matrix.duckdb_arch }}" --bucket duckdb-extensions-nightly
-
-  test_wasm:
-    name: Deploy Wasm (${{ matrix.duckdb_arch }})
-    needs: [matrix, build_wasm]
-    if: ${{ !cancelled() && needs.matrix.outputs.test_wasm != '' && needs.matrix.outputs.test_wasm != '{"include":[]}' && needs.build_wasm.result == 'success' }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix.outputs.test_wasm) }}
-    env:
-      CI_PLATFORM: wasm
-      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-      CI_EXTENSION_NAME: all-extensions
-      CI_EXTENSION_ARTIFACT_DIR: ${{ github.workspace }}/.ci/repository
-    steps:
-      - name: Checkout extension
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: ${{ inputs.extension_repository != '' && inputs.extension_repository || github.repository }}
-          ref: ${{ inputs.extension_ref }}
-          fetch-depth: 0
-          submodules: recursive
-      - name: Checkout extension-ci-tools
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          path: extension-ci-tools
-          repository: ${{ inputs.ci_tools_repository }}
-          ref: ${{ inputs.ci_tools_version }}
-      - name: Setup Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: "3.11"
-      - name: Prepare sources
-        run: python3 extension-ci-tools/scripts/ci_phase.py checkout
-      - name: Download extension artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          pattern: ${{ matrix.artifact_pattern }}
-          path: ${{ github.workspace }}/.ci/repository
-          merge-multiple: true
-      - name: Skip Wasm tests
-        if: ${{ !inputs.skip_tests }}
-        run: python3 extension-ci-tools/scripts/ci_phase.py test
-      - name: Deploy extensions
-        if: ${{ inputs.deploy }}
-        shell: bash
-        env:
-          AWS_ENDPOINT_URL: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ENDPOINT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY }}
-          DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.S3_DUCKDB_ORG_EXTENSION_SIGNING_PK }}
-          DUCKDB_DEPLOY_SCRIPT_MODE: ${{ secrets.DUCKDB_EXTENSIONS_NIGHTLY_S3_KEY != '' && 'for_real' || '' }}
-          PIP_BREAK_SYSTEM_PACKAGES: 1
-        run: |
-          python3 -m pip install awscli
-          git fetch --tags
-          git -C duckdb fetch --tags
-          extension_version="$(git tag --points-at HEAD | head -n 1)"
-          extension_version="${extension_version:-$(git rev-parse --short HEAD)}"
-          duckdb_version="$(git -C duckdb tag --points-at HEAD | head -n 1)"
-          duckdb_version="${duckdb_version:-$(git -C duckdb rev-parse --short HEAD)}"
-          python3 extension-ci-tools/scripts/deploy_artifacts.py --root "$CI_EXTENSION_ARTIFACT_DIR" --script ./duckdb/scripts/extension-upload-single.sh --extension-version "$extension_version" --duckdb-version "$duckdb_version" --architecture "${{ matrix.duckdb_arch }}" --bucket duckdb-extensions-nightly

--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -131,18 +131,14 @@ class PhaseRunner:
 
     def checkout(self) -> None:
         duckdb_repository = self.value("CI_DUCKDB_GIT_REPOSITORY")
+        duckdb_version = self.value("CI_DUCKDB_VERSION")
         if duckdb_repository:
             self.run(
-                ["make", "set_duckdb_repository"],
-                extra_env={"DUCKDB_GIT_REPOSITORY": duckdb_repository},
+                ["git", "-C", "duckdb", "remote", "set-url", "origin", duckdb_repository]
             )
-
-        duckdb_version = self.value("CI_DUCKDB_VERSION")
         if duckdb_version:
-            self.run(
-                ["make", "set_duckdb_version"],
-                extra_env={"DUCKDB_GIT_VERSION": duckdb_version},
-            )
+            self.run(["git", "-C", "duckdb", "fetch", "origin", duckdb_version])
+            self.run(["git", "-C", "duckdb", "checkout", duckdb_version])
 
         extension_tag = self.value("CI_EXTENSION_TAG")
         if extension_tag:

--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -16,6 +16,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tarfile
 from typing import Mapping, Sequence
 
 
@@ -151,7 +152,22 @@ class PhaseRunner:
             self.run(["make", "set_duckdb_tag"], extra_env={"DUCKDB_TAG": duckdb_tag})
 
     def inject_extension_config(self) -> None:
-        config = self.value("CI_EXTRA_EXTENSION_CONFIG")
+        config_parts: list[str] = []
+        raw_paths = self.value("CI_EXTENSION_CONFIG_PATHS", "[]")
+        paths = json.loads(raw_paths)
+        if not isinstance(paths, list) or not all(isinstance(path, str) for path in paths):
+            raise ValueError("CI_EXTENSION_CONFIG_PATHS must be a JSON string array")
+        for configured_path in paths:
+            path = Path(configured_path)
+            if not path.is_absolute():
+                path = self.workspace / path
+            if not path.is_file():
+                raise FileNotFoundError(f"extension config does not exist: {path}")
+            config_parts.append(path.read_text(encoding="utf-8").rstrip("\n"))
+        inline_config = self.value("CI_EXTRA_EXTENSION_CONFIG")
+        if inline_config:
+            config_parts.append(inline_config.rstrip("\n"))
+        config = "\n\n".join(part for part in config_parts if part)
         if not config:
             return
         path = self.workspace / "extension_config.cmake"
@@ -202,6 +218,12 @@ class PhaseRunner:
                 self.run(["vcpkg", "install", dependency, "--recurse"])
 
     def setup_linux(self) -> None:
+        if self.enabled("CI_LINUX_NATIVE_CONTAINER"):
+            self.run_with_retry(
+                ["make", "configure_ci"],
+                extra_env=self.build_environment(),
+            )
+            return
         if self.enabled("CI_USE_DEFAULT_RUNNERS"):
             if self.enabled("CI_RUN_DISK_CLEAN_STEP"):
                 images = subprocess.run(
@@ -393,6 +415,12 @@ class PhaseRunner:
                 handle.write(f"{key}={value}\n")
 
     def build_linux(self) -> None:
+        if self.enabled("CI_LINUX_NATIVE_CONTAINER"):
+            self.run_with_retry(
+                ["make", self.required("CI_BUILD_TYPE")],
+                extra_env=self.build_environment(),
+            )
+            return
         self.run(
             [
                 "docker",
@@ -478,9 +506,12 @@ class PhaseRunner:
             if self.architecture == "linux_arm64":
                 print("Tests are not supported for linux_arm64.")
                 return
-            self.run([*self.docker_arguments(), "make", target])
-            environment["LINUX_CI_IN_DOCKER"] = "0"
-            self.run(["make", target], extra_env=environment)
+            if self.enabled("CI_LINUX_NATIVE_CONTAINER"):
+                self.run(["make", target], extra_env=environment)
+            else:
+                self.run([*self.docker_arguments(), "make", target])
+                environment["LINUX_CI_IN_DOCKER"] = "0"
+                self.run(["make", target], extra_env=environment)
         elif self.platform == "macos":
             if self.value("CI_OSX_BUILD_ARCH") != "arm64":
                 print("Tests run only on the native macOS arm64 build.")
@@ -526,7 +557,7 @@ class PhaseRunner:
         matches = glob.glob(str(self.workspace / path), recursive=True)
         if not matches:
             raise FileNotFoundError(f"no artifact matched {path}")
-        name = (
+        name = self.value("CI_ARTIFACT_NAME") or (
             f"{self.required('CI_EXTENSION_NAME')}-{self.value('CI_DUCKDB_VERSION')}-extension-"
             f"{self.architecture}{self.value('CI_ARTIFACT_POSTFIX')}"
         )
@@ -534,10 +565,99 @@ class PhaseRunner:
         self.append_github_file("GITHUB_OUTPUT", "artifact_name", name)
         self.print_rust_logs()
 
+    def bundle_test_support(self) -> None:
+        if self.enabled("CI_SKIP_TESTS") or self.platform == "wasm":
+            return
+        build_type = self.required("CI_BUILD_TYPE")
+        build_dir = self.workspace / "build" / build_type
+        if not build_dir.is_dir():
+            raise FileNotFoundError(f"build directory does not exist: {build_dir}")
+
+        artifact_root = self.workspace / ".ci" / "test-support" / build_type
+        if artifact_root.parent.exists():
+            shutil.rmtree(artifact_root.parent)
+        artifact_root.mkdir(parents=True)
+
+        required = [build_dir / "test" / "unittest"]
+        if os.name == "nt":
+            required = [build_dir / "test" / "unittest.exe"]
+        for source in required:
+            if not source.is_file():
+                raise FileNotFoundError(f"test support file does not exist: {source}")
+
+        candidates = [
+            build_dir / "duckdb",
+            build_dir / "duckdb.exe",
+            build_dir / "test" / "run",
+            build_dir / "test" / "run.exe",
+            build_dir / "test" / "unittest",
+            build_dir / "test" / "unittest.exe",
+        ]
+        for source in candidates:
+            if source.is_file():
+                destination = artifact_root / source.relative_to(build_dir)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, destination)
+
+        for pattern in (
+            "src/libduckdb.*",
+            "test/extension/*.duckdb_extension",
+            "test/extension/*.duckdb_extension.wasm",
+        ):
+            for source in build_dir.glob(pattern):
+                destination = artifact_root / source.relative_to(build_dir)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, destination)
+
+        archive = self.workspace / ".ci" / "test-support.tar.gz"
+        with tarfile.open(archive, "w:gz", compresslevel=4) as bundle:
+            bundle.add(artifact_root, arcname=build_type)
+        self.append_github_file("GITHUB_OUTPUT", "test_support_path", str(archive))
+
+    def test_supports(self) -> None:
+        if self.enabled("CI_SKIP_TESTS"):
+            print("Tests skipped by workflow input.")
+            return
+        support_root = Path(self.required("CI_TEST_SUPPORT_DIR"))
+        repository_root = Path(self.required("CI_EXTENSION_ARTIFACT_DIR"))
+        archives = sorted(support_root.glob("**/test-support.tar.gz"))
+        if not archives:
+            raise FileNotFoundError(f"no test-support archives found below {support_root}")
+
+        build_type = self.required("CI_BUILD_TYPE")
+        build_root = self.workspace / "build"
+        build_dir = build_root / build_type
+        for archive in archives:
+            if build_dir.exists():
+                shutil.rmtree(build_dir)
+            with tarfile.open(archive, "r:gz") as bundle:
+                members = bundle.getmembers()
+                for member in members:
+                    destination = (build_root / member.name).resolve()
+                    if build_root.resolve() not in destination.parents and destination != build_root.resolve():
+                        raise ValueError(f"unsafe path in test-support archive: {member.name}")
+                bundle.extractall(build_root)
+            destination_repository = build_dir / "repository"
+            destination_repository.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(repository_root, destination_repository, dirs_exist_ok=True)
+            print(f"Testing support bundle from {archive}")
+            self.test()
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("phase", choices=("checkout", "setup", "build", "test", "upload"))
+    parser.add_argument(
+        "phase",
+        choices=(
+            "checkout",
+            "setup",
+            "build",
+            "test",
+            "upload",
+            "bundle_test_support",
+            "test_supports",
+        ),
+    )
     args = parser.parse_args()
     runner = PhaseRunner()
     try:

--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -575,7 +575,7 @@ class PhaseRunner:
             f"{self.architecture}{self.value('CI_ARTIFACT_POSTFIX')}"
         )
         artifact_id = hashlib.sha256(name.encode("utf-8")).hexdigest()[:16]
-        staging = self.workspace / "build" / "ci-artifacts" / artifact_id
+        staging = self.workspace / "ci-artifacts" / artifact_id
         if staging.exists():
             shutil.rmtree(staging)
         staging.mkdir(parents=True)

--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import glob
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -493,19 +494,13 @@ class PhaseRunner:
     def build(self) -> None:
         getattr(self, f"build_{self.platform}")()
 
-    def test(self) -> None:
-        if self.enabled("CI_SKIP_TESTS"):
-            print("Tests skipped by workflow input.")
-            return
+    def _run_tests(self) -> None:
         environment = self.build_environment()
         environment["SUBSET_EXTENSIONS_TESTS"] = self.value("CI_EXTENSIONS_TEST_SELECTION")
         environment.update(test_environment(self.value("CI_TEST_CONFIG", "{}")))
         target = f"test_{self.required('CI_BUILD_TYPE')}"
 
         if self.platform == "linux":
-            if self.architecture == "linux_arm64":
-                print("Tests are not supported for linux_arm64.")
-                return
             if self.enabled("CI_LINUX_NATIVE_CONTAINER"):
                 self.run(["make", target], extra_env=environment)
             else:
@@ -513,14 +508,29 @@ class PhaseRunner:
                 environment["LINUX_CI_IN_DOCKER"] = "0"
                 self.run(["make", target], extra_env=environment)
         elif self.platform == "macos":
-            if self.value("CI_OSX_BUILD_ARCH") != "arm64":
-                print("Tests run only on the native macOS arm64 build.")
-                return
             self.run(["make", target], extra_env=environment)
         elif self.platform == "windows":
             self.run(["make", target], extra_env=environment)
-        else:
+
+    def test(self) -> None:
+        if self.enabled("CI_SKIP_TESTS"):
+            print("Tests skipped by workflow input.")
+            return
+        if self.platform == "linux" and self.architecture == "linux_arm64":
+            print("Tests are not supported for linux_arm64.")
+            return
+        if self.platform == "macos" and self.value("CI_OSX_BUILD_ARCH") != "arm64":
+            print("Tests run only on the native macOS arm64 build.")
+            return
+        if self.platform == "wasm":
             print("The Wasm distribution job has no test target.")
+            return
+
+        repository = self.value("CI_EXTENSION_ARTIFACT_DIR")
+        if repository:
+            self._test_artifacts(Path(repository))
+            return
+        self._run_tests()
 
     def artifact_path(self) -> str:
         all_extensions = self.enabled("CI_UPLOAD_ALL_EXTENSIONS")
@@ -554,28 +564,61 @@ class PhaseRunner:
 
     def upload(self) -> None:
         path = self.artifact_path()
-        matches = glob.glob(str(self.workspace / path), recursive=True)
+        matches = sorted(
+            Path(match)
+            for match in glob.glob(str(self.workspace / path), recursive=True)
+        )
         if not matches:
             raise FileNotFoundError(f"no artifact matched {path}")
         name = self.value("CI_ARTIFACT_NAME") or (
             f"{self.required('CI_EXTENSION_NAME')}-{self.value('CI_DUCKDB_VERSION')}-extension-"
             f"{self.architecture}{self.value('CI_ARTIFACT_POSTFIX')}"
         )
-        self.append_github_file("GITHUB_OUTPUT", "artifact_path", path)
+        artifact_id = hashlib.sha256(name.encode("utf-8")).hexdigest()[:16]
+        staging = self.workspace / "build" / "ci-artifacts" / artifact_id
+        if staging.exists():
+            shutil.rmtree(staging)
+        staging.mkdir(parents=True)
+
+        build_base = self.workspace / "build" / (
+            self.architecture if self.platform == "wasm" else self.required("CI_BUILD_TYPE")
+        )
+        source_root = (
+            build_base / "repository"
+            if self.enabled("CI_UPLOAD_ALL_EXTENSIONS")
+            else build_base / "extension" / self.required("CI_EXTENSION_NAME")
+        )
+        for source in matches:
+            destination = staging / source.relative_to(source_root)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+
+        if self._test_support_enabled():
+            archive = staging / "test-support" / artifact_id / "test-support.tar.gz"
+            self._bundle_test_support(archive)
+
+        self.append_github_file("GITHUB_OUTPUT", "artifact_path", str(staging))
         self.append_github_file("GITHUB_OUTPUT", "artifact_name", name)
         self.print_rust_logs()
 
-    def bundle_test_support(self) -> None:
+    def _test_support_enabled(self) -> bool:
         if self.enabled("CI_SKIP_TESTS") or self.platform == "wasm":
-            return
+            return False
+        if self.platform == "linux":
+            return self.architecture != "linux_arm64"
+        if self.platform == "macos":
+            return self.value("CI_OSX_BUILD_ARCH") == "arm64"
+        return self.platform == "windows"
+
+    def _bundle_test_support(self, archive: Path) -> None:
         build_type = self.required("CI_BUILD_TYPE")
         build_dir = self.workspace / "build" / build_type
         if not build_dir.is_dir():
             raise FileNotFoundError(f"build directory does not exist: {build_dir}")
 
         artifact_root = self.workspace / ".ci" / "test-support" / build_type
-        if artifact_root.parent.exists():
-            shutil.rmtree(artifact_root.parent)
+        if artifact_root.exists():
+            shutil.rmtree(artifact_root)
         artifact_root.mkdir(parents=True)
 
         required = [build_dir / "test" / "unittest"]
@@ -609,20 +652,14 @@ class PhaseRunner:
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(source, destination)
 
-        archive = self.workspace / ".ci" / "test-support.tar.gz"
+        archive.parent.mkdir(parents=True, exist_ok=True)
         with tarfile.open(archive, "w:gz", compresslevel=4) as bundle:
             bundle.add(artifact_root, arcname=build_type)
-        self.append_github_file("GITHUB_OUTPUT", "test_support_path", str(archive))
 
-    def test_supports(self) -> None:
-        if self.enabled("CI_SKIP_TESTS"):
-            print("Tests skipped by workflow input.")
-            return
-        support_root = Path(self.required("CI_TEST_SUPPORT_DIR"))
-        repository_root = Path(self.required("CI_EXTENSION_ARTIFACT_DIR"))
-        archives = sorted(support_root.glob("**/test-support.tar.gz"))
+    def _test_artifacts(self, repository_root: Path) -> None:
+        archives = sorted((repository_root / "test-support").glob("**/test-support.tar.gz"))
         if not archives:
-            raise FileNotFoundError(f"no test-support archives found below {support_root}")
+            raise FileNotFoundError(f"no test-support archives found below {repository_root}")
 
         build_type = self.required("CI_BUILD_TYPE")
         build_root = self.workspace / "build"
@@ -639,9 +676,14 @@ class PhaseRunner:
                 bundle.extractall(build_root)
             destination_repository = build_dir / "repository"
             destination_repository.mkdir(parents=True, exist_ok=True)
-            shutil.copytree(repository_root, destination_repository, dirs_exist_ok=True)
+            shutil.copytree(
+                repository_root,
+                destination_repository,
+                dirs_exist_ok=True,
+                ignore=shutil.ignore_patterns("test-support"),
+            )
             print(f"Testing support bundle from {archive}")
-            self.test()
+            self._run_tests()
 
 
 def main() -> None:
@@ -654,8 +696,6 @@ def main() -> None:
             "build",
             "test",
             "upload",
-            "bundle_test_support",
-            "test_supports",
         ),
     )
     args = parser.parse_args()

--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -621,13 +621,6 @@ class PhaseRunner:
             shutil.rmtree(artifact_root)
         artifact_root.mkdir(parents=True)
 
-        required = [build_dir / "test" / "unittest"]
-        if os.name == "nt":
-            required = [build_dir / "test" / "unittest.exe"]
-        for source in required:
-            if not source.is_file():
-                raise FileNotFoundError(f"test support file does not exist: {source}")
-
         candidates = [
             build_dir / "duckdb",
             build_dir / "duckdb.exe",

--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -132,7 +132,17 @@ class PhaseRunner:
     def checkout(self) -> None:
         duckdb_repository = self.value("CI_DUCKDB_GIT_REPOSITORY")
         duckdb_version = self.value("CI_DUCKDB_VERSION")
-        if duckdb_repository:
+        duckdb_directory = self.workspace / "duckdb"
+        if not duckdb_directory.is_dir():
+            self.run(
+                [
+                    "git",
+                    "clone",
+                    duckdb_repository or "https://github.com/duckdb/duckdb.git",
+                    "duckdb",
+                ]
+            )
+        elif duckdb_repository:
             self.run(
                 ["git", "-C", "duckdb", "remote", "set-url", "origin", duckdb_repository]
             )

--- a/scripts/deploy_artifacts.py
+++ b/scripts/deploy_artifacts.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
+from pathlib import Path, PurePath
 import shutil
 import subprocess
 import tempfile
@@ -45,7 +45,7 @@ def discover_extensions(root: Path) -> list[tuple[str, Path]]:
 
 def deploy_extensions(
     root: Path,
-    script: Path,
+    script: PurePath,
     extension_version: str,
     duckdb_version: str,
     architecture: str,
@@ -64,7 +64,7 @@ def deploy_extensions(
             subprocess.run(
                 [
                     "bash",
-                    str(script),
+                    script.as_posix(),
                     name,
                     extension_version,
                     duckdb_version,
@@ -72,7 +72,7 @@ def deploy_extensions(
                     bucket,
                     str(deploy_latest).lower(),
                     str(deploy_versioned).lower(),
-                    str(staging),
+                    staging.as_posix(),
                 ],
                 check=True,
             )

--- a/scripts/deploy_artifacts.py
+++ b/scripts/deploy_artifacts.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Deploy every unique extension binary found in downloaded group artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+def extension_name(path: Path) -> str:
+    wasm_suffix = ".duckdb_extension.wasm"
+    native_suffix = ".duckdb_extension"
+    if path.name.endswith(wasm_suffix):
+        return path.name[: -len(wasm_suffix)]
+    if path.name.endswith(native_suffix):
+        return path.name[: -len(native_suffix)]
+    raise ValueError(f"not a DuckDB extension binary: {path}")
+
+
+def discover_extensions(root: Path) -> list[tuple[str, Path]]:
+    candidates = sorted(
+        path
+        for path in root.rglob("*.duckdb_extension*")
+        if path.is_file()
+        and (
+            path.name.endswith(".duckdb_extension")
+            or path.name.endswith(".duckdb_extension.wasm")
+        )
+    )
+    selected: dict[str, Path] = {}
+    for path in candidates:
+        name = extension_name(path)
+        if name in selected:
+            print(
+                f"warning: skipping duplicate extension {name!r}: {path} "
+                f"(using {selected[name]})"
+            )
+            continue
+        selected[name] = path
+    return list(selected.items())
+
+
+def deploy_extensions(
+    root: Path,
+    script: Path,
+    extension_version: str,
+    duckdb_version: str,
+    architecture: str,
+    bucket: str,
+    deploy_latest: bool,
+    deploy_versioned: bool,
+) -> None:
+    extensions = discover_extensions(root)
+    if not extensions:
+        raise FileNotFoundError(f"no extension binaries found below {root}")
+    with tempfile.TemporaryDirectory(prefix="duckdb-extension-deploy-") as directory:
+        staging = Path(directory)
+        for name, source in extensions:
+            destination = staging / source.name
+            shutil.copy2(source, destination)
+            subprocess.run(
+                [
+                    "bash",
+                    str(script),
+                    name,
+                    extension_version,
+                    duckdb_version,
+                    architecture,
+                    bucket,
+                    str(deploy_latest).lower(),
+                    str(deploy_versioned).lower(),
+                    str(staging),
+                ],
+                check=True,
+            )
+            destination.unlink()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--script", type=Path, required=True)
+    parser.add_argument("--extension-version", required=True)
+    parser.add_argument("--duckdb-version", required=True)
+    parser.add_argument("--architecture", required=True)
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument("--latest", action="store_true")
+    parser.add_argument("--versioned", action="store_true")
+    args = parser.parse_args()
+    deploy_extensions(
+        args.root,
+        args.script,
+        args.extension_version,
+        args.duckdb_version,
+        args.architecture,
+        args.bucket,
+        args.latest,
+        args.versioned,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_ci_phase.py
+++ b/scripts/test_ci_phase.py
@@ -255,6 +255,7 @@ class CIPhaseTest(unittest.TestCase):
                     if line.startswith("artifact_path=")
                 )
             )
+            self.assertEqual(artifact_path.parent, workspace.resolve() / "ci-artifacts")
             self.assertTrue((artifact_path / artifact.name).is_file())
             self.assertFalse((artifact_path / "test-support").exists())
             self.assertIn("artifact_name=quack-v1.2.3-extension-linux_amd64", values)

--- a/scripts/test_ci_phase.py
+++ b/scripts/test_ci_phase.py
@@ -83,15 +83,7 @@ class CIPhaseTest(unittest.TestCase):
             self.assertEqual(
                 commands,
                 [
-                    [
-                        "git",
-                        "-C",
-                        "duckdb",
-                        "remote",
-                        "set-url",
-                        "origin",
-                        "duckdb/duckdb-fork",
-                    ],
+                    ["git", "clone", "duckdb/duckdb-fork", "duckdb"],
                     ["git", "-C", "duckdb", "fetch", "origin", "v1.2.3"],
                     ["git", "-C", "duckdb", "checkout", "v1.2.3"],
                     ["git", "tag", "v2.0.0"],
@@ -99,7 +91,7 @@ class CIPhaseTest(unittest.TestCase):
                 ],
             )
 
-    def test_checkout_fetches_version_without_repository_override(self):
+    def test_checkout_clones_default_repository(self):
         with tempfile.TemporaryDirectory() as directory:
             env = self.environment(directory)
             runner = RecordingRunner(env)
@@ -108,6 +100,38 @@ class CIPhaseTest(unittest.TestCase):
             self.assertEqual(
                 commands,
                 [
+                    [
+                        "git",
+                        "clone",
+                        "https://github.com/duckdb/duckdb.git",
+                        "duckdb",
+                    ],
+                    ["git", "-C", "duckdb", "fetch", "origin", "v1.2.3"],
+                    ["git", "-C", "duckdb", "checkout", "v1.2.3"],
+                ],
+            )
+
+    def test_checkout_reuses_existing_duckdb_repository(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            (workspace / "duckdb").mkdir()
+            env = self.environment(workspace)
+            env["CI_DUCKDB_GIT_REPOSITORY"] = "https://github.com/duckdb/duckdb.git"
+            runner = RecordingRunner(env)
+            runner.checkout()
+            commands = [command for command, _ in runner.commands]
+            self.assertEqual(
+                commands,
+                [
+                    [
+                        "git",
+                        "-C",
+                        "duckdb",
+                        "remote",
+                        "set-url",
+                        "origin",
+                        "https://github.com/duckdb/duckdb.git",
+                    ],
                     ["git", "-C", "duckdb", "fetch", "origin", "v1.2.3"],
                     ["git", "-C", "duckdb", "checkout", "v1.2.3"],
                 ],

--- a/scripts/test_ci_phase.py
+++ b/scripts/test_ci_phase.py
@@ -2,8 +2,10 @@ from contextlib import redirect_stderr
 import io
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import unittest
 from unittest import mock
@@ -119,6 +121,42 @@ class CIPhaseTest(unittest.TestCase):
             self.assertEqual(runner.commands[0][0][-2:], ["make", "test_release"])
             self.assertEqual(runner.commands[1][0], ["make", "test_release"])
 
+    def test_linux_native_container_build_and_test_do_not_use_docker(self):
+        with tempfile.TemporaryDirectory() as directory:
+            env = self.environment(directory)
+            env["CI_LINUX_NATIVE_CONTAINER"] = "true"
+            runner = RecordingRunner(env)
+            runner.setup_linux()
+            runner.build_linux()
+            runner.test()
+            self.assertEqual(runner.commands[0][0], ["make", "configure_ci"])
+            self.assertEqual(runner.commands[1][0][-2:], ["make", "release"])
+            self.assertEqual(runner.commands[2][0], ["make", "test_release"])
+            self.assertNotIn("docker", str(runner.commands))
+
+    def test_extension_config_paths_are_resolved_from_workspace(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            (workspace / "extension_config.cmake").write_text("set(BASE 1)\n", encoding="utf-8")
+            config = workspace / "config" / "group.cmake"
+            config.parent.mkdir()
+            config.write_text("set(GROUP 1)\n", encoding="utf-8")
+            env = self.environment(workspace)
+            env["CI_EXTENSION_CONFIG_PATHS"] = '["config/group.cmake"]'
+            runner = RecordingRunner(env)
+            runner.inject_extension_config()
+            contents = (workspace / "extension_config.cmake").read_text(encoding="utf-8")
+            self.assertIn("set(BASE 1)", contents)
+            self.assertIn("set(GROUP 1)", contents)
+
+    def test_missing_extension_config_path_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            env = self.environment(directory)
+            env["CI_EXTENSION_CONFIG_PATHS"] = '["missing.cmake"]'
+            runner = RecordingRunner(env)
+            with self.assertRaises(FileNotFoundError):
+                runner.inject_extension_config()
+
     def test_failed_phase_command_exits_concisely_for_list_and_shell_commands(self):
         commands = (
             (["make", "test release"], "make 'test release'"),
@@ -217,6 +255,41 @@ class CIPhaseTest(unittest.TestCase):
             runner = RecordingRunner(self.environment(directory))
             with self.assertRaises(FileNotFoundError):
                 runner.upload()
+
+    def test_bundle_and_restore_test_support_uses_external_repository(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            build = workspace / "build" / "release"
+            unittest_binary = build / "test" / ("unittest.exe" if os.name == "nt" else "unittest")
+            unittest_binary.parent.mkdir(parents=True)
+            unittest_binary.write_text("runner", encoding="utf-8")
+            repository = workspace / "downloaded-repository" / "v1" / "linux_amd64"
+            repository.mkdir(parents=True)
+            (repository / "quack.duckdb_extension").write_text("extension", encoding="utf-8")
+
+            output = workspace / "github-output"
+            env = self.environment(workspace)
+            env["GITHUB_OUTPUT"] = str(output)
+            runner = RecordingRunner(env)
+            runner.bundle_test_support()
+            archive = workspace / ".ci" / "test-support.tar.gz"
+            self.assertTrue(archive.is_file())
+            with tarfile.open(archive, "r:gz") as bundle:
+                names = bundle.getnames()
+            self.assertIn(f"release/test/{unittest_binary.name}", names)
+            self.assertFalse(any("repository" in name for name in names))
+
+            support_dir = workspace / "support" / "main"
+            support_dir.mkdir(parents=True)
+            shutil.copy2(archive, support_dir / archive.name)
+            env["CI_TEST_SUPPORT_DIR"] = str(workspace / "support")
+            env["CI_EXTENSION_ARTIFACT_DIR"] = str(workspace / "downloaded-repository")
+            restored = RecordingRunner(env)
+            restored.test_supports()
+            self.assertTrue(
+                (build / "repository" / "v1" / "linux_amd64" / "quack.duckdb_extension").is_file()
+            )
+            self.assertEqual(restored.commands[0][0][-2:], ["make", "test_release"])
 
 
 if __name__ == "__main__":

--- a/scripts/test_ci_phase.py
+++ b/scripts/test_ci_phase.py
@@ -243,11 +243,20 @@ class CIPhaseTest(unittest.TestCase):
             artifact.touch()
             output = workspace / "github-output"
             env = self.environment(workspace)
+            env["CI_SKIP_TESTS"] = "true"
             env["GITHUB_OUTPUT"] = str(output)
             runner = RecordingRunner(env)
             runner.upload()
             values = output.read_text(encoding="utf-8")
-            self.assertIn("artifact_path=build/release/extension/quack/quack.duckdb_extension", values)
+            artifact_path = Path(
+                next(
+                    line.removeprefix("artifact_path=")
+                    for line in values.splitlines()
+                    if line.startswith("artifact_path=")
+                )
+            )
+            self.assertTrue((artifact_path / artifact.name).is_file())
+            self.assertFalse((artifact_path / "test-support").exists())
             self.assertIn("artifact_name=quack-v1.2.3-extension-linux_amd64", values)
 
     def test_upload_fails_when_artifact_is_missing(self):
@@ -256,40 +265,90 @@ class CIPhaseTest(unittest.TestCase):
             with self.assertRaises(FileNotFoundError):
                 runner.upload()
 
-    def test_bundle_and_restore_test_support_uses_external_repository(self):
+    def test_upload_fails_when_required_test_support_is_missing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            artifact = workspace / "build/release/extension/quack/quack.duckdb_extension"
+            artifact.parent.mkdir(parents=True)
+            artifact.touch()
+            runner = RecordingRunner(self.environment(workspace))
+            with self.assertRaises(FileNotFoundError):
+                runner.upload()
+
+    def test_upload_and_test_restore_embedded_group_support(self):
         with tempfile.TemporaryDirectory() as directory:
             workspace = Path(directory)
             build = workspace / "build" / "release"
             unittest_binary = build / "test" / ("unittest.exe" if os.name == "nt" else "unittest")
             unittest_binary.parent.mkdir(parents=True)
             unittest_binary.write_text("runner", encoding="utf-8")
-            repository = workspace / "downloaded-repository" / "v1" / "linux_amd64"
+            unittest_binary.chmod(0o755)
+            repository = build / "repository" / "v1" / "linux_amd64"
             repository.mkdir(parents=True)
             (repository / "quack.duckdb_extension").write_text("extension", encoding="utf-8")
 
-            output = workspace / "github-output"
             env = self.environment(workspace)
-            env["GITHUB_OUTPUT"] = str(output)
-            runner = RecordingRunner(env)
-            runner.bundle_test_support()
-            archive = workspace / ".ci" / "test-support.tar.gz"
-            self.assertTrue(archive.is_file())
+            env["CI_UPLOAD_ALL_EXTENSIONS"] = "true"
+            downloaded = workspace / "downloaded-repository"
+            for group in ("group-one", "group-two"):
+                output = workspace / f"github-output-{group}"
+                env["CI_ARTIFACT_NAME"] = group
+                env["GITHUB_OUTPUT"] = str(output)
+                PhaseRunner(env).upload()
+                values = output.read_text(encoding="utf-8")
+                artifact_path = Path(
+                    next(
+                        line.removeprefix("artifact_path=")
+                        for line in values.splitlines()
+                        if line.startswith("artifact_path=")
+                    )
+                )
+                shutil.copytree(artifact_path, downloaded, dirs_exist_ok=True)
+
+            archives = sorted(downloaded.glob("test-support/**/test-support.tar.gz"))
+            self.assertEqual(len(archives), 2)
+            archive = archives[0]
             with tarfile.open(archive, "r:gz") as bundle:
                 names = bundle.getnames()
+                unittest_member = bundle.getmember(f"release/test/{unittest_binary.name}")
             self.assertIn(f"release/test/{unittest_binary.name}", names)
             self.assertFalse(any("repository" in name for name in names))
+            if os.name != "nt":
+                self.assertNotEqual(unittest_member.mode & 0o111, 0)
 
-            support_dir = workspace / "support" / "main"
-            support_dir.mkdir(parents=True)
-            shutil.copy2(archive, support_dir / archive.name)
-            env["CI_TEST_SUPPORT_DIR"] = str(workspace / "support")
-            env["CI_EXTENSION_ARTIFACT_DIR"] = str(workspace / "downloaded-repository")
+            env["CI_EXTENSION_ARTIFACT_DIR"] = str(downloaded)
             restored = RecordingRunner(env)
-            restored.test_supports()
+            restored.test()
             self.assertTrue(
                 (build / "repository" / "v1" / "linux_amd64" / "quack.duckdb_extension").is_file()
             )
+            self.assertFalse((build / "repository" / "test-support").exists())
             self.assertEqual(restored.commands[0][0][-2:], ["make", "test_release"])
+            self.assertEqual(len(restored.commands), 4)
+
+    def test_support_is_enabled_only_for_testable_platforms(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cases = (
+                (self.environment(directory), True),
+                (self.environment(directory, "linux", "linux_arm64"), False),
+                (self.environment(directory, "wasm", "wasm_eh"), False),
+                (self.environment(directory, "windows", "windows_amd64"), True),
+            )
+            macos_env = self.environment(directory, "macos", "osx_amd64")
+            macos_env["CI_OSX_BUILD_ARCH"] = "x86_64"
+            cases += ((macos_env, False),)
+            native_macos_env = self.environment(directory, "macos", "osx_arm64")
+            native_macos_env["CI_OSX_BUILD_ARCH"] = "arm64"
+            cases += ((native_macos_env, True),)
+
+            for env, expected in cases:
+                with self.subTest(
+                    platform=env["CI_PLATFORM"],
+                    architecture=env["DUCKDB_PLATFORM"],
+                ):
+                    self.assertEqual(
+                        RecordingRunner(env)._test_support_enabled(), expected
+                    )
 
 
 if __name__ == "__main__":

--- a/scripts/test_ci_phase.py
+++ b/scripts/test_ci_phase.py
@@ -83,10 +83,33 @@ class CIPhaseTest(unittest.TestCase):
             self.assertEqual(
                 commands,
                 [
-                    ["make", "set_duckdb_repository"],
-                    ["make", "set_duckdb_version"],
+                    [
+                        "git",
+                        "-C",
+                        "duckdb",
+                        "remote",
+                        "set-url",
+                        "origin",
+                        "duckdb/duckdb-fork",
+                    ],
+                    ["git", "-C", "duckdb", "fetch", "origin", "v1.2.3"],
+                    ["git", "-C", "duckdb", "checkout", "v1.2.3"],
                     ["git", "tag", "v2.0.0"],
                     ["make", "set_duckdb_tag"],
+                ],
+            )
+
+    def test_checkout_fetches_version_without_repository_override(self):
+        with tempfile.TemporaryDirectory() as directory:
+            env = self.environment(directory)
+            runner = RecordingRunner(env)
+            runner.checkout()
+            commands = [command for command, _ in runner.commands]
+            self.assertEqual(
+                commands,
+                [
+                    ["git", "-C", "duckdb", "fetch", "origin", "v1.2.3"],
+                    ["git", "-C", "duckdb", "checkout", "v1.2.3"],
                 ],
             )
 

--- a/scripts/test_ci_phase.py
+++ b/scripts/test_ci_phase.py
@@ -266,15 +266,31 @@ class CIPhaseTest(unittest.TestCase):
             with self.assertRaises(FileNotFoundError):
                 runner.upload()
 
-    def test_upload_fails_when_required_test_support_is_missing(self):
+    def test_upload_allows_missing_unittest_binary(self):
         with tempfile.TemporaryDirectory() as directory:
             workspace = Path(directory)
             artifact = workspace / "build/release/extension/quack/quack.duckdb_extension"
             artifact.parent.mkdir(parents=True)
             artifact.touch()
-            runner = RecordingRunner(self.environment(workspace))
-            with self.assertRaises(FileNotFoundError):
-                runner.upload()
+            output = workspace / "github-output"
+            env = self.environment(workspace)
+            env["GITHUB_OUTPUT"] = str(output)
+            RecordingRunner(env).upload()
+
+            values = output.read_text(encoding="utf-8")
+            artifact_path = Path(
+                next(
+                    line.removeprefix("artifact_path=")
+                    for line in values.splitlines()
+                    if line.startswith("artifact_path=")
+                )
+            )
+            archives = list(artifact_path.glob("test-support/**/test-support.tar.gz"))
+            self.assertEqual(len(archives), 1)
+            with tarfile.open(archives[0], "r:gz") as bundle:
+                self.assertFalse(
+                    any(Path(name).name.startswith("unittest") for name in bundle.getnames())
+                )
 
     def test_upload_and_test_restore_embedded_group_support(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test_deploy_artifacts.py
+++ b/scripts/test_deploy_artifacts.py
@@ -1,0 +1,62 @@
+from contextlib import redirect_stdout
+import io
+from pathlib import Path
+import tempfile
+import unittest
+
+from unittest import mock
+
+from deploy_artifacts import deploy_extensions, discover_extensions
+
+
+class DeployArtifactsTest(unittest.TestCase):
+    def test_discovery_is_sorted_and_keeps_first_duplicate(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "a" / "quack.duckdb_extension"
+            duplicate = root / "b" / "quack.duckdb_extension"
+            wasm = root / "b" / "web.duckdb_extension.wasm"
+            for path in (first, duplicate, wasm):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.touch()
+            output = io.StringIO()
+            with redirect_stdout(output):
+                extensions = discover_extensions(root)
+            self.assertEqual(extensions, [("quack", first), ("web", wasm)])
+            self.assertIn("skipping duplicate extension 'quack'", output.getvalue())
+
+    @mock.patch("deploy_artifacts.subprocess.run")
+    def test_deploy_invokes_script_for_each_extension(self, run):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            extension = root / "v1" / "linux_amd64" / "quack.duckdb_extension"
+            extension.parent.mkdir(parents=True)
+            extension.write_text("binary", encoding="utf-8")
+            deploy_extensions(
+                root,
+                Path("duckdb/scripts/extension-upload-single.sh"),
+                "abc123",
+                "v1.2.3",
+                "linux_amd64",
+                "bucket",
+                True,
+                False,
+            )
+            command = run.call_args.args[0]
+            self.assertEqual(command[:8], [
+                "bash",
+                "duckdb/scripts/extension-upload-single.sh",
+                "quack",
+                "abc123",
+                "v1.2.3",
+                "linux_amd64",
+                "bucket",
+                "true",
+            ])
+            self.assertEqual(command[8], "false")
+            self.assertTrue(command[9])
+            run.assert_called_once_with(command, check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_deploy_artifacts.py
+++ b/scripts/test_deploy_artifacts.py
@@ -1,6 +1,6 @@
 from contextlib import redirect_stdout
 import io
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 import tempfile
 import unittest
 
@@ -34,7 +34,7 @@ class DeployArtifactsTest(unittest.TestCase):
             extension.write_text("binary", encoding="utf-8")
             deploy_extensions(
                 root,
-                Path("duckdb/scripts/extension-upload-single.sh"),
+                PureWindowsPath(r"duckdb\scripts\extension-upload-single.sh"),
                 "abc123",
                 "v1.2.3",
                 "linux_amd64",
@@ -55,6 +55,7 @@ class DeployArtifactsTest(unittest.TestCase):
             ])
             self.assertEqual(command[8], "false")
             self.assertTrue(command[9])
+            self.assertNotIn("\\", command[9])
             run.assert_called_once_with(command, check=True)
 
 


### PR DESCRIPTION
Currently, the extension jobs are sharded, and therefore building and testing a subset of the extension inside one CI job. Some extensions have tests that depend on other extensions (like httpfs) and if that extension in not available in the same CI job, the test is skipped.

This PR splits the extension jobs into build and test jobs. The test job can download the artifacts from the build job (eventually using an older distro image) and run tests on all extensions inside the same machine. 

The new workflow `build.yml` is tested in duckdb core CI here: https://github.com/duckdb/duckdb/pull/24769/.

TODO:
- [x] Use build-duckdb action to fix vcpkg [issue](https://github.com/duckdb/duckdb/actions/runs/31809994331/job/94801270635)?
- [x] Add `save_cache` to `build.yml`.
- [x] Use pinned commit hashes for all actions.