### PR TITLE
Allow some archs like musl to fail (for alpha releases)

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -48,6 +48,11 @@ on:
         required: false
         type: string
         default: ""
+      # ';' separated list of architectures that should not fail the workflow
+      allow_failure_archs:
+        required: false
+        type: string
+        default: ""
       # Postfix added to artifact names. Can be used to guarantee unique names when this workflow is called multiple times
       artifact_postfix:
         required: false
@@ -277,6 +282,7 @@ jobs:
 
   linux:
     name: ${{ matrix.duckdb_arch }}
+    continue-on-error: ${{ contains(format(';{0};', inputs.allow_failure_archs), format(';{0};', matrix.duckdb_arch)) }}
     runs-on: ${{ startsWith(matrix.runner, '[') && fromJSON(matrix.runner) || matrix.runner }}
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.linux_matrix != '{}' && needs.generate_matrix.outputs.linux_matrix != '' }}


### PR DESCRIPTION
If a musl build fails for an extension group, we're not running the downstream checks (benchmarks, clients, etc.) because the dispatch call is checking if all previous CI jobs succeeded.

The extension workflow is one "job" in that sense so any extension job that fails gives:
```
### Check CI status
Run NEEDS_JSON='{
One or more required jobs failed or were cancelled.
extensions: failure
Error: Process completed with exit code 1.
```
and the release dispatch call is skipped (because it cannot distinguish if the whole extensions workflow failed or a subset).

`allow_failure_archs` sets `continue-on-error: true` for specific platforms (like musl) so we can continue the CI run and downstream checks for alpha release builds.

Note: we omit `allow_failure_archs` for official release builds, so we avoid releasing a duckdb version without (partial) musl extensions. This logic is done on the workflow caller side.