### PR TITLE
Reuse the vcpkg archives a previous run already built

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -357,12 +357,35 @@ jobs:
             ccache-extension-distribution-${{ matrix.duckdb_arch }}-
           save: ${{ inputs.save_cache }}
 
+
+      # A manifest names the same dependency set from one run to the next, so
+      # the archives vcpkg produces for it are reusable: the key is the vcpkg
+      # commit, the target triplet and the manifest itself, and a run whose
+      # dependencies are unchanged restores them instead of compiling them.
+      - name: Setup / vcpkg binary cache
+        run: mkdir -p .vcpkg_cache
+
+      - name: Setup / Load vcpkg binary cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ./.vcpkg_cache
+          key: vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg_ports/**') }}-${{ github.run_id }}
+          restore-keys: |
+            vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg_ports/**') }}
+            vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-
       - name: Setup
         run: python3 extension-ci-tools/scripts/ci_phase.py setup
 
       - name: Build
         run: python3 extension-ci-tools/scripts/ci_phase.py build
 
+
+      - name: Upload / Save vcpkg binary cache
+        if: ${{ inputs.save_cache }}
+        uses: actions/cache/save@v4
+        with:
+          path: ./.vcpkg_cache
+          key: vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg_ports/**') }}-${{ github.run_id }}
       - name: Test
         run: python3 extension-ci-tools/scripts/ci_phase.py test
 
@@ -464,12 +487,35 @@ jobs:
             ccache-extension-distribution-${{ matrix.duckdb_arch }}-
           save: ${{ inputs.save_cache }}
 
+
+      # A manifest names the same dependency set from one run to the next, so
+      # the archives vcpkg produces for it are reusable: the key is the vcpkg
+      # commit, the target triplet and the manifest itself, and a run whose
+      # dependencies are unchanged restores them instead of compiling them.
+      - name: Setup / vcpkg binary cache
+        run: mkdir -p .vcpkg_cache
+
+      - name: Setup / Load vcpkg binary cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ./.vcpkg_cache
+          key: vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg_ports/**') }}-${{ github.run_id }}
+          restore-keys: |
+            vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg_ports/**') }}
+            vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-
       - name: Setup
         run: python3 extension-ci-tools/scripts/ci_phase.py setup
 
       - name: Build
         run: python3 extension-ci-tools/scripts/ci_phase.py build
 
+
+      - name: Upload / Save vcpkg binary cache
+        if: ${{ inputs.save_cache }}
+        uses: actions/cache/save@v4
+        with:
+          path: ./.vcpkg_cache
+          key: vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg_ports/**') }}-${{ github.run_id }}
       - name: Test
         run: python3 extension-ci-tools/scripts/ci_phase.py test
 
@@ -585,6 +631,22 @@ jobs:
             ccache-extension-distribution-${{ matrix.duckdb_arch }}-
           save: ${{ inputs.save_cache }}
 
+
+      # A manifest names the same dependency set from one run to the next, so
+      # the archives vcpkg produces for it are reusable: the key is the vcpkg
+      # commit, the target triplet and the manifest itself, and a run whose
+      # dependencies are unchanged restores them instead of compiling them.
+      - name: Setup / vcpkg binary cache
+        run: mkdir -p .vcpkg_cache
+
+      - name: Setup / Load vcpkg binary cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ./.vcpkg_cache
+          key: vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg_ports/**') }}-${{ github.run_id }}
+          restore-keys: |
+            vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg_ports/**') }}
+            vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-
       - name: Setup / Rtools
         if: ${{ matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw' }}
         uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
@@ -614,6 +676,13 @@ jobs:
       - name: Build
         run: python extension-ci-tools/scripts/ci_phase.py build
 
+
+      - name: Upload / Save vcpkg binary cache
+        if: ${{ inputs.save_cache }}
+        uses: actions/cache/save@v4
+        with:
+          path: ./.vcpkg_cache
+          key: vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg_ports/**') }}-${{ github.run_id }}
       - name: Test
         run: python extension-ci-tools/scripts/ci_phase.py test
 
@@ -723,12 +792,35 @@ jobs:
             ccache-extension-distribution-${{ matrix.duckdb_arch }}-
           save: ${{ inputs.save_cache }}
 
+
+      # A manifest names the same dependency set from one run to the next, so
+      # the archives vcpkg produces for it are reusable: the key is the vcpkg
+      # commit, the target triplet and the manifest itself, and a run whose
+      # dependencies are unchanged restores them instead of compiling them.
+      - name: Setup / vcpkg binary cache
+        run: mkdir -p .vcpkg_cache
+
+      - name: Setup / Load vcpkg binary cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ./.vcpkg_cache
+          key: vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg_ports/**') }}-${{ github.run_id }}
+          restore-keys: |
+            vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg_ports/**') }}
+            vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-
       - name: Setup
         run: python3 extension-ci-tools/scripts/ci_phase.py setup
 
       - name: Build
         run: python3 extension-ci-tools/scripts/ci_phase.py build
 
+
+      - name: Upload / Save vcpkg binary cache
+        if: ${{ inputs.save_cache }}
+        uses: actions/cache/save@v4
+        with:
+          path: ./.vcpkg_cache
+          key: vcpkg-extension-distribution-${{ matrix.duckdb_arch }}-${{ matrix.vcpkg_target_triplet }}-${{ inputs.vcpkg_commit }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg_ports/**') }}-${{ github.run_id }}
       - name: Test
         run: python3 extension-ci-tools/scripts/ci_phase.py test
 

--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -322,7 +322,10 @@ class PhaseRunner:
             self.run(["aws", "--version"])
         self.run_with_retry(
             ["make", "configure_ci"],
-            extra_env={"DUCKDB_GIT_VERSION": self.value("CI_DUCKDB_VERSION")},
+            extra_env={
+                **self.vcpkg_cache_environment(),
+                "DUCKDB_GIT_VERSION": self.value("CI_DUCKDB_VERSION"),
+            },
         )
         self.install_extra_vcpkg_dependencies()
 
@@ -330,9 +333,22 @@ class PhaseRunner:
         self.inject_extension_config()
         getattr(self, f"setup_{self.platform}")()
 
+    def vcpkg_cache_environment(self) -> dict[str, str]:
+        # Off Linux the build runs on the runner rather than in a container, so
+        # the cache vcpkg reads and writes is the workspace directory itself.
+        cache = self.workspace / ".vcpkg_cache"
+        cache.mkdir(parents=True, exist_ok=True)
+        sources = self.value("VCPKG_BINARY_SOURCES")
+        sources = f"{sources};files,{cache},readwrite" if sources else f"files,{cache},readwrite"
+        return {
+            "VCPKG_BINARY_SOURCES": sources,
+            "VCPKG_DEFAULT_BINARY_CACHE": str(cache),
+        }
+
     def build_environment(self) -> dict[str, str]:
         is_rtools = self.architecture in {"windows_amd64_rtools", "windows_amd64_mingw"}
         return {
+            **self.vcpkg_cache_environment(),
             "DUCKDB_PLATFORM": self.architecture,
             "DUCKDB_PLATFORM_RTOOLS": "1" if is_rtools else "0",
             "DUCKDB_GIT_VERSION": self.value("CI_DUCKDB_VERSION"),
@@ -351,12 +367,21 @@ class PhaseRunner:
             f"{self.workspace}:/duckdb_build_dir",
             "-v",
             f"{self.workspace / '.ccache'}:/ccache_dir",
+            "-v",
+            f"{self.workspace / '.vcpkg_cache'}:/vcpkg_cache",
             f"duckdb/{self.architecture}",
         ]
 
     def create_docker_environment(self) -> None:
+        # The archives vcpkg builds are reusable between runs, so the cache the
+        # workspace carries is offered as a read-write source beside whatever
+        # read-only ones are configured.
+        binary_sources = self.value("VCPKG_BINARY_SOURCES")
+        binary_sources = f"{binary_sources};files,/vcpkg_cache,readwrite" if binary_sources \
+            else "files,/vcpkg_cache,readwrite"
         values = {
-            "VCPKG_BINARY_SOURCES": self.value("VCPKG_BINARY_SOURCES"),
+            "VCPKG_BINARY_SOURCES": binary_sources,
+            "VCPKG_DEFAULT_BINARY_CACHE": "/vcpkg_cache",
             "USE_MERGED_VCPKG_MANIFEST": self.value("USE_MERGED_VCPKG_MANIFEST"),
             "AWS_ACCESS_KEY_ID": self.value("AWS_ACCESS_KEY_ID"),
             "AWS_SECRET_ACCESS_KEY": self.value("AWS_SECRET_ACCESS_KEY"),


### PR DESCRIPTION
A manifest names the same dependency set from one run to the next, so the
archives vcpkg produces for it are reusable, yet the only binary source
configured is the public read-only cache, which holds an archive for the
dependency sets DuckDB itself builds. An extension whose manifest names an
overlay port of its own, or a feature selection of its own, compiles its whole
dependency tree on every job of every run.

Measured on one such extension (MobilityDuck, which carries a MEOS port and
builds GDAL with `geos,network`): twenty-seven of twenty-eight packages compile
from source — GDAL 4.1 minutes, GEOS 1.8, PROJ 1.6, OpenSSL 1.1, and twenty
smaller ones — 12.7 minutes of a 27.7-minute Linux job, and the larger share of
a macOS one. Exactly one package restores, in 666 milliseconds.

Each job carries a binary cache directory in its workspace and offers it to
vcpkg as a read-write source beside whatever read-only ones are configured,
restored and saved through the same Actions cache the compiler cache beside it
already uses. The key is the vcpkg commit, the target triplet and a hash of the
calling extension's manifest and overlay ports, so a dependency change misses
and everything else hits; the prefixes it falls back to let a pull request read
what a run on the default branch saved. The Linux job mounts the directory into
the container that runs vcpkg, the other three point vcpkg at it directly.

An extension with no port of its own keeps restoring from the public cache
exactly as before, and the new source is additive, so a configured
`vcpkg_binary_sources` is preserved and simply gains the local cache.

`scripts/test_ci_phase.py` reports 11 passed both before and after (the one
collection error is pre-existing: pytest collects the `test_environment` helper
in `ci_phase.py`).
