### PR TITLE
Support DUCKDB_VERSION and DUCKDB_COMMIT variables

### DIFF
--- a/scripts/ci_phase.py
+++ b/scripts/ci_phase.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import shlex
 import shutil
 import subprocess
@@ -64,6 +65,12 @@ def extra_dependencies(config: str, architecture: str) -> list[str]:
 class PhaseRunner:
     def __init__(self, environ: Mapping[str, str] | None = None) -> None:
         self.env = dict(os.environ if environ is None else environ)
+        duckdb_tag = self.env.get("CI_DUCKDB_TAG", "")
+        if duckdb_tag:
+            self.env.setdefault("DUCKDB_VERSION", duckdb_tag)
+        duckdb_ref = self.env.get("CI_DUCKDB_VERSION", "")
+        if re.fullmatch(r"[0-9a-fA-F]{10,64}", duckdb_ref):
+            self.env.setdefault("DUCKDB_COMMIT", duckdb_ref)
         self.platform = self.required("CI_PLATFORM")
         self.architecture = self.required("DUCKDB_PLATFORM")
         self.workspace = Path(self.env.get("GITHUB_WORKSPACE", ".")).resolve()
@@ -362,6 +369,8 @@ class PhaseRunner:
     def build_environment(self) -> dict[str, str]:
         is_rtools = self.architecture in {"windows_amd64_rtools", "windows_amd64_mingw"}
         return {
+            "DUCKDB_VERSION": self.value("DUCKDB_VERSION"),
+            "DUCKDB_COMMIT": self.value("DUCKDB_COMMIT"),
             "DUCKDB_PLATFORM": self.architecture,
             "DUCKDB_PLATFORM_RTOOLS": "1" if is_rtools else "0",
             "DUCKDB_GIT_VERSION": self.value("CI_DUCKDB_VERSION"),
@@ -401,6 +410,8 @@ class PhaseRunner:
             "OPENSSL_ROOT_DIR": f"/duckdb_build_dir/build/{self.value('CI_BUILD_TYPE')}/vcpkg_installed/{self.value('VCPKG_TARGET_TRIPLET')}",
             "OPENSSL_DIR": f"/duckdb_build_dir/build/{self.value('CI_BUILD_TYPE')}/vcpkg_installed/{self.value('VCPKG_TARGET_TRIPLET')}",
             "OPENSSL_USE_STATIC_LIBS": "true",
+            "DUCKDB_VERSION": self.value("DUCKDB_VERSION"),
+            "DUCKDB_COMMIT": self.value("DUCKDB_COMMIT"),
             "DUCKDB_PLATFORM": self.architecture,
             "DUCKDB_GIT_VERSION": self.value("CI_DUCKDB_VERSION"),
             "ENABLE_EXTENSION_AUTOINSTALL": "1",

--- a/scripts/test_ci_phase.py
+++ b/scripts/test_ci_phase.py
@@ -67,6 +67,57 @@ class CIPhaseTest(unittest.TestCase):
         )
         self.assertEqual(extra_dependencies("{}", "linux_amd64"), [])
 
+    def test_duckdb_build_identity_is_derived_from_workflow_inputs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            commit = "0123456789abcdef0123456789abcdef01234567"
+            env = self.environment(directory)
+            env.update(
+                {
+                    "CI_DUCKDB_TAG": "v2.0.0-alpha39940",
+                    "CI_DUCKDB_VERSION": commit,
+                }
+            )
+            runner = RecordingRunner(env)
+
+            self.assertEqual(runner.env["DUCKDB_VERSION"], "v2.0.0-alpha39940")
+            self.assertEqual(runner.env["DUCKDB_COMMIT"], commit)
+            native_environment = runner.build_environment()
+            self.assertEqual(native_environment["DUCKDB_VERSION"], "v2.0.0-alpha39940")
+            self.assertEqual(native_environment["DUCKDB_COMMIT"], commit)
+
+            runner.create_docker_environment()
+            docker_environment = Path(directory, "docker_env.txt").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("DUCKDB_VERSION=v2.0.0-alpha39940\n", docker_environment)
+            self.assertIn(f"DUCKDB_COMMIT={commit}\n", docker_environment)
+
+    def test_duckdb_checkout_ref_becomes_commit_only_when_hexadecimal(self):
+        with tempfile.TemporaryDirectory() as directory:
+            for checkout_ref in ("main", "feature/identity", "v2.0.0"):
+                with self.subTest(checkout_ref=checkout_ref):
+                    env = self.environment(directory)
+                    env["CI_DUCKDB_VERSION"] = checkout_ref
+                    runner = RecordingRunner(env)
+                    self.assertNotIn("DUCKDB_COMMIT", runner.env)
+                    self.assertEqual(runner.build_environment()["DUCKDB_COMMIT"], "")
+
+    def test_explicit_duckdb_build_identity_takes_precedence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            env = self.environment(directory)
+            env.update(
+                {
+                    "CI_DUCKDB_TAG": "v2.0.0-alpha39940",
+                    "CI_DUCKDB_VERSION": "0123456789abcdef0123456789abcdef01234567",
+                    "DUCKDB_VERSION": "v9.9.9-explicit",
+                    "DUCKDB_COMMIT": "fedcba9876543210",
+                }
+            )
+            runner = RecordingRunner(env)
+
+            self.assertEqual(runner.env["DUCKDB_VERSION"], "v9.9.9-explicit")
+            self.assertEqual(runner.env["DUCKDB_COMMIT"], "fedcba9876543210")
+
     def test_checkout_runs_only_requested_operations(self):
         with tempfile.TemporaryDirectory() as directory:
             env = self.environment(directory)
@@ -89,6 +140,10 @@ class CIPhaseTest(unittest.TestCase):
                     ["git", "tag", "v2.0.0"],
                     ["make", "set_duckdb_tag"],
                 ],
+            )
+            self.assertEqual(
+                runner.commands[-1][1]["extra_env"],
+                {"DUCKDB_TAG": "v1.2.3-test"},
             )
 
     def test_checkout_clones_default_repository(self):


### PR DESCRIPTION
We've [simplified](https://github.com/duckdb/duckdb/pull/25180) duckdb version/commit in duckdb main.

This PR derives DUCKDB_VERSION and DUCKDB_COMMIT variables from existing variables. The variables do not override existing values, so only set when missing.